### PR TITLE
Use javac rather than java to locate JDK

### DIFF
--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -69,7 +69,7 @@
 (defcustom ensime-default-java-home
   (cond ((getenv "JDK_HOME"))
 	((getenv "JAVA_HOME"))
-	('t (let ((java (file-truename (executable-find "java"))))
+	('t (let ((java (file-truename (executable-find "javac"))))
 	      (warn "JDK_HOME and JAVA_HOME are not set, inferring from %s" java)
 	      (ensime--parent-dir (ensime--parent-dir java)))))
   "Location of the JDK's base directory"


### PR DESCRIPTION
Use javac rather than java to determine ensime-default-java-home when the JDK_HOME and JAVA_HOME environment variables aren't set.
