### PR TITLE
Derive more ensime faces from standard faces.

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -316,16 +316,12 @@
   "Key bindings for the build result popup.")
 
 (defface ensime-compile-errline
-  '((((class color) (background dark)) (:foreground "#ff5555"))
-    (((class color) (background light)) (:foreground "Firebrick4"))
-    (t (:bold t)))
+  '((t (:inherit compilation-error)))
   "Face used for marking the line on which an error occurs."
   :group 'ensime-ui)
 
 (defface ensime-compile-warnline
-  '((((class color) (background dark)) (:foreground "LightBlue2"))
-    (((class color) (background light)) (:foreground "DarkBlue"))
-    (t (:bold t)))
+  '((t (:inherit compilation-warning)))
   "Face used for marking the line on which an warning occurs."
   :group 'ensime-ui)
 

--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -20,42 +20,6 @@
 ;;     MA 02111-1307, USA.
 
 
-(defvar ensime-sem-high-all-faces
-  '(
-    (var . (:foreground "#ff2222"))
-    (val . (:foreground "#dddddd"))
-    (varField . (:foreground "#ff3333"))
-    (valField . (:foreground "#dddddd"))
-    (functionCall . (:foreground "#84BEE3"))
-    (operator . (:foreground "#bbbbbb"))
-    (param . (:foreground "#ffffff"))
-    (class . font-lock-type-face)
-    (trait . (:foreground "#084EA8"))
-    (object . (:foreground "#026DF7"))
-    (package . font-lock-preprocessor-face)
-    ))
-
-(defvar ensime-sem-high-default-faces
-  '())
-
-(defvar ensime-sem-high-faces
-  ensime-sem-high-default-faces
-  "Faces for semantic highlighting. Symbol types not mentioned here
- will not be requested from server.")
-
-(defun ensime-sem-high-enable-all ()
-  "Enable full semantic highlighting."
-  (interactive)
-  (setq ensime-sem-high-faces
-	ensime-sem-high-all-faces)
-  (ensime-sem-high-refresh-all-buffers))
-
-(defun ensime-sem-high-disable-all ()
-  "Disable all semantic highlighting."
-  (interactive)
-  (setq ensime-sem-high-faces '())
-  (ensime-sem-high-refresh-all-buffers))
-
 (defun ensime-sem-high-apply-properties (info)
   "Use provided info to modify font-lock properties of identifiers
  in the program text."
@@ -110,14 +74,15 @@
 
 (defun ensime-sem-high-refresh-region (beg end)
   "Refresh semantic highlighting for the given region."
-  (ensime-rpc-symbol-designations
-   buffer-file-name beg end
-   (mapcar 'car ensime-sem-high-faces)
-   `(lambda (info)
-      (ensime-sem-high-clear-region ,beg ,end)
-      (ensime-sem-high-apply-properties info)
-      (ensime-event-sig :region-sem-highlighted nil)
-      )))
+  (when ensime-sem-high-enabled-p
+    (ensime-rpc-symbol-designations
+     buffer-file-name (ensime-externalize-offset beg) (ensime-externalize-offset end)
+     (mapcar 'car ensime-sem-high-faces)
+     `(lambda (info)
+        (ensime-sem-high-clear-region ,beg ,end)
+        (ensime-sem-high-apply-properties info)
+        (ensime-event-sig :region-sem-highlighted nil)
+        ))))
 
 (defun ensime-sem-high-inspect-highlight ()
   (interactive)

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -119,6 +119,32 @@ since the last typecheck."
   :type 'number
   :group 'ensime-ui)
 
+(defcustom ensime-sem-high-enabled-p t
+  "If true, ensime semantic highlighting is applied whenever the buffer
+is saved."
+  :type 'boolean
+  :group 'ensime-ui)
+
+(defcustom ensime-sem-high-faces
+  '((var . scala-font-lock:var-face)
+    (val . (:inherit font-lock-constant-face :slant italic))
+    (varField . scala-font-lock:var-face)
+    (valField . (:inherit font-lock-constant-face :slant italic))
+    (functionCall . font-lock-function-name-face)
+    (operator . font-lock-keyword-face)
+    (param . (:slant italic))
+    (class . font-lock-type-face)
+    (trait .  (:inherit font-lock-type-face :slant italic))
+    (object . (:inherit font-lock-type-face :underline t))
+    (package . font-lock-preprocessor-face))
+  "Faces for semantic highlighting. Symbol types not mentioned here
+will not be requested from server.  The format is an alist of the form
+  ( SYMBOL-TYPE . FACE-SPEC )
+where SYMBOL-TYPE is one of:
+  var val varField valField functionCall
+  operator params class trait object package"
+  :type 'alist
+  :group 'ensime-ui)
 
 (provide 'ensime-vars)
 


### PR DESCRIPTION
This lets us enable semantic highlighting by default. I've always thought that ensime should flaunt that feature!

Feel free to criticize my aesthetic choices!

This fixes ensime/ensime-server#490
