### PR TITLE
Toggle between loading "some files" and "all files" in the presentation compiler

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -1030,8 +1030,14 @@ with the current project's dependencies loaded. Returns a property list."
 (defun ensime-rpc-remove-file (file-name)
   (ensime-eval `(swank:remove-file ,file-name)))
 
+(defun ensime-rpc-unload-all ()
+  (ensime-eval `(swank:unload-all)))
+
 (defun ensime-rpc-async-typecheck-file (file-name continue)
   (ensime-eval-async `(swank:typecheck-file ,file-name) continue))
+
+(defun ensime-rpc-async-typecheck-files (file-names continue)
+  (ensime-eval-async `(swank:typecheck-files ,file-names) continue))
 
 (defun ensime-rpc-async-typecheck-file-with-contents (file-name contents continue)
   (ensime-eval-async `(swank:typecheck-file ,file-name ,contents)

--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -401,6 +401,19 @@
         (progn
           (ensime-rpc-async-typecheck-file buffer-file-name 'identity))))))
 
+(defun ensime-reload-open-files ()
+  "Make the ENSIME server forget about all files ; reload .class files
+in the project's path ;  then reload only the Scala files that are
+currently open in emacs."
+  (interactive)
+  (message "Unloading all files...")
+  (ensime-rpc-unload-all)
+  (message "Reloading open files...")
+  (setf (ensime-last-typecheck-run-time (ensime-connection)) (float-time))
+  (let ((files (mapcar #'buffer-file-name
+                       (ensime-connection-visiting-buffers (ensime-connection)))))
+    (ensime-rpc-async-typecheck-files files 'identity)))
+
 (defun ensime-typecheck-all ()
   "Send a request for re-typecheck of whole project to the ENSIME server.
    Current file is saved if it has unwritten modifications."

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -55,9 +55,6 @@
 	'ensime-inspect-type-at-point-other-frame)
       (define-key prefix-map (kbd "C-v p") 'ensime-inspect-package-at-point)
       (define-key prefix-map (kbd "C-v o") 'ensime-inspect-project-package)
-      (define-key prefix-map (kbd "C-v c") 'ensime-typecheck-current-file)
-      (define-key prefix-map (kbd "C-v a") 'ensime-typecheck-all)
-      (define-key prefix-map (kbd "C-v e") 'ensime-show-all-errors-and-warnings)
       (define-key prefix-map (kbd "C-v r") 'ensime-show-uses-of-symbol-at-point)
       (define-key prefix-map (kbd "C-v s") 'ensime-sbt-switch)
       (define-key prefix-map (kbd "C-v z") 'ensime-inf-switch)
@@ -67,6 +64,11 @@
       (define-key prefix-map (kbd "C-v x") 'ensime-scalex)
       (define-key prefix-map (kbd "C-v t") 'ensime-show-doc-for-symbol-at-point)
       (define-key prefix-map (kbd "C-v .") 'ensime-expand-selection-command)
+
+      (define-key prefix-map (kbd "C-c c") 'ensime-typecheck-current-file)
+      (define-key prefix-map (kbd "C-c a") 'ensime-typecheck-all)
+      (define-key prefix-map (kbd "C-c r") 'ensime-reload-open-files)
+      (define-key prefix-map (kbd "C-c e") 'ensime-show-all-errors-and-warnings)
 
       (define-key prefix-map (kbd "C-t t") 'ensime-goto-test)
       (define-key prefix-map (kbd "C-t i") 'ensime-goto-impl)
@@ -138,10 +140,13 @@
      ["Inspect type in another frame" ensime-inspect-type-at-point-other-frame]
      ["Inspect enclosing package" ensime-inspect-package-at-point]
      ["Inspect project package" ensime-inspect-project-package]
+     ["Undo source change" ensime-undo-peek])
+
+    ("Typecheck"
      ["Typecheck file" ensime-typecheck-current-file]
      ["Typecheck project" ensime-typecheck-all]
-     ["Show all errors and warnings" ensime-show-all-errors-and-warnings]
-     ["Undo source change" ensime-undo-peek])
+     ["Reload typecheker" ensime-reload-open-files]
+     ["Show all errors and warnings" ensime-show-all-errors-and-warnings])
 
     ("Refactor"
      ["Organize imports" ensime-refactor-organize-imports]


### PR DESCRIPTION
This goes with ensime/ensime-server#615.  The explanation that follows is as long as the actual code change, but it's important to understand how the user experience is affected.
- I moved all presentation compiler commands to the `C-c C-c` prefix
- The "new behavior" is to not load all sources in the PC at startup.
- The "old behavior" (all files loaded) can be restored by simply typing `C-c C-c a`  (formerly `C-c C-v a`). This  only need to be done once per session.
- Switching from the "old behavior" back to the "new behavior" is done with `C-c C-c r`  ("reload open files").

When the "new behavior" is in effect:
- things won't work well until the project is compiled. This is a major change from a user's point of view.
- editing source code will cause only a few files to be reparsed by the PC so it should be very snappy. The drawback is that type information etc. may not propagate between all open files. This can only be fixed by recompiling.  The server will notice that .class files have changed thanks to @fommil's excellent work, and update its state.

The one thing that won't work with the "new behavior" is `C-c C-v r` and `C-c C-r r`:  both functions rely on passing all sources to scala-refactoring. I suggest to fix this in a separate ticket. In the meantime, a workaround is to use `C-c C-c a`  before a search to revert to the old behavior.
