### PR TITLE
function/key combo to print the type at point

### DIFF
--- a/ensime-inspector.el
+++ b/ensime-inspector.el
@@ -7,6 +7,13 @@
 (defvar ensime-indent-level 0
   "In inspector UI, how much to indent.")
 
+(defun ensime-print-type-at-point ()
+  "Echo the type at point to the minibuffer."
+  (interactive)
+  (let* ((type (ensime-rpc-get-type-at-point))
+         (fullname (ensime-type-full-name-with-args type)))
+    (message fullname)))
+
 (defun ensime-inspector-buffer-p (buffer)
   "Is this an ensime inspector buffer?"
   (eq (get-buffer ensime-inspector-buffer-name) buffer))

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -62,7 +62,8 @@
       (define-key prefix-map (kbd "C-v u") 'ensime-undo-peek)
       (define-key prefix-map (kbd "C-v v") 'ensime-search)
       (define-key prefix-map (kbd "C-v x") 'ensime-scalex)
-      (define-key prefix-map (kbd "C-v t") 'ensime-show-doc-for-symbol-at-point)
+      (define-key prefix-map (kbd "C-v d") 'ensime-show-doc-for-symbol-at-point)
+      (define-key prefix-map (kbd "C-v t") 'ensime-print-type-at-point)
       (define-key prefix-map (kbd "C-v .") 'ensime-expand-selection-command)
 
       (define-key prefix-map (kbd "C-c c") 'ensime-typecheck-current-file)


### PR DESCRIPTION
been wanting this one for ages, but finally found some time on a plane to do it.

I figured this warranted a change to the javadoc keybinding because it never made sense to me why it took `t`.
