### PR TITLE
disable compile on save by default

### DIFF
--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -46,7 +46,7 @@
   :group 'ensime
   :prefix "ensime-sbt-")
 
-(defcustom ensime-sbt-perform-on-save "compile"
+(defcustom ensime-sbt-perform-on-save nil
   "Which (if any) sbt action to perform when a file is saved."
   :type '(choice (const nil) string)
   :group 'ensime-sbt)


### PR DESCRIPTION
I don't believe this should be the default. The whole point of the presentation compiler is to avoid doing a full recompile and this only makes sense for **really** small projects.
