### PR TITLE
Improve the user experience for initial startup (resolves #697).

### DIFF
--- a/ensime-config.el
+++ b/ensime-config.el
@@ -27,6 +27,26 @@
 
 (add-to-list 'auto-mode-alist '("\\.ensime$" . emacs-lisp-mode))
 
+(defun ensime-config-source-roots (conf)
+  "Returns a list of all directories mentioned in :source-roots directives."
+  (let ((subs (plist-get conf :subprojects)))
+    (-mapcat (lambda (sub) (plist-get sub :source-roots)) subs)))
+
+(defun ensime-config-includes-source-file
+    (conf file &optional no-ref-sources)
+  "Returns t if the given file is contained in the :source-roots or (if "
+  "no-ref-sources is nil) :source-jars-dir of the given project."
+  (when file
+    (let ((source-roots
+	   (-filter
+	    'file-directory-p
+	    (append (ensime-config-source-roots conf)
+		    (unless no-ref-sources
+		      (when-let (dir (plist-get conf :source-jars-dir))
+				(list dir)))))))
+      (-first (lambda (dir) (ensime-path-prefix-p file dir))
+	      source-roots))))
+
 (defmacro ensime-set-key (conf key val)
   `(setq ,conf (plist-put ,conf ,key ,val)))
 

--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -286,7 +286,7 @@
         (find-file-other-window effective-file)
       (find-file effective-file))
 
-    (when (ensime-file-in-directory-p effective-file (ensime-source-jars-dir))
+    (when (ensime-path-prefix-p effective-file (ensime-source-jars-dir))
       (with-current-buffer (get-file-buffer effective-file)
         (setq buffer-read-only t)))))
 

--- a/ensime-goto-testfile.el
+++ b/ensime-goto-testfile.el
@@ -60,7 +60,7 @@ ensime configuration."
                  (plist-get (ensime-config (ensime-connection)) :source-roots))))
     (let ((dir
            (find-if
-            #'(lambda (dir) (ensime-file-in-directory-p file-name dir))
+            #'(lambda (dir) (ensime-path-prefix-p file-name dir))
             all-sources)))
       (when dir (file-name-as-directory (expand-file-name dir))))))
 

--- a/ensime-util.el
+++ b/ensime-util.el
@@ -102,22 +102,12 @@ argument is supplied) is a .scala or .java file."
 (defun ensime-visiting-scala-file-p ()
   (ensime-scala-file-p buffer-file-name))
 
-(defun ensime-file-in-directory-p (file-name dir-name)
-  "Determine if file named by file-name is contained in the
-   directory named by dir-name."
+(defun ensime-path-prefix-p (file-name dir-name)
+  "Expands both file-name and dir-name and returns t if dir-name is a
+ prefix of file-name. Does not touch the file system."
   (let* ((dir (file-name-as-directory (expand-file-name dir-name)))
-	 (file (expand-file-name file-name))
-	 (d file))
-    (catch 'return
-      (while d
-	(let ((d-original d))
-	  (setq d (file-name-directory
-		   (directory-file-name d)))
-	  (when (equal dir d)
-	    (throw 'return t))
-	  (when (equal d d-original)
-	    (throw 'return nil))
-	  )))))
+	 (file (expand-file-name file-name)))
+    (string-prefix-p dir file)))
 
 (defun ensime-temp-file-name (name)
   "Return the path of a temp file with filename 'name'."


### PR DESCRIPTION
Sending this out early to get feedback. Things seem to work.
- Takes the server process into account when computing the 'mode-line'. If a given source file 'belongs' to a server process, but there is no connection present, the mode-line will read 'Starting...'. This motivated some refactoring of the 'owning-connection-for-source-file' logic, moving much code to ensime-config.
- Replenishes connection attempts if the server buffer shows any action.
- Pops the server buffer in a secondary window when you run M-x ensime (without stealing focus). The idea being to make it obvious what is taking so damn long.
