### PR TITLE
Fix ensime/ensime-server#701: do not rely on buffer-file-coding-system

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -75,10 +75,12 @@
 		       (len (- to from)))
 		  (goto-char (+ p (- from chunk-start)))
 		  (delete-char (min len (- (point-max) (point))))
+
+                  (when (eq 1 (coding-system-eol-type chunk-coding-system))
+                    (setq text (replace-regexp-in-string "\r$" "" text)))
+
                   (let ((start (point)))
                     (insert text)
-                    (recode-region start (point)
-                                   chunk-coding-system buffer-file-coding-system)
                     (set-text-properties start (point) '(face font-lock-keyword-face)))))
 
 	      (goto-char (point-max))


### PR DESCRIPTION
The objective is to prevent displaying control-m's in replacement text. This behavior depends only on the coding system of the file being edited, not that of the current buffer.
