### PR TITLE
Cache the current connection at each buffer, to avoid repeated, costly lookups.

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -161,8 +161,12 @@ overrides `ensime-buffer-connection'.")
  more than one connection. "
   (or (ensime-proc-if-alive ensime-dispatching-connection)
       (ensime-proc-if-alive ensime-buffer-connection)
-      (ensime-proc-if-alive
-       (ensime-owning-connection-for-source-file buffer-file-name))))
+      (when-let (conn (ensime-proc-if-alive
+		       (ensime-owning-connection-for-source-file
+			buffer-file-name)))
+		;; Cache the connection so lookup is fast next time.
+		(setq ensime-buffer-connection conn)
+		conn)))
 
 (defun ensime-proc-if-alive (proc)
   "Returns proc if proc's buffer is alive, otherwise returns nil."


### PR DESCRIPTION
I noticed while profiling some completion code that connection lookup was taking an inordinate amount of time (see profiler snapshot below, sampled while completing a method)
![image](https://cloud.githubusercontent.com/assets/7484/5422488/ab38522e-8251-11e4-90e2-b9c4ad1e581f.png)
