### PR TITLE
Fixes for emacs integration tests (resolves #710)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: scala
+
+jdk:
+- openjdk6
+
+env:
+  matrix:
+    - "EMACS=emacs24 ENSIME_TEST_SERVER_VERSION=2.10.4"
+
+install:
+  - if [ "$EMACS" = "emacs23" ]; then
+        sudo apt-get update -qq &&
+        sudo apt-get install -qq emacs23-gtk emacs23-el;
+    fi
+  - if [ "$EMACS" = "emacs24" ]; then
+        sudo add-apt-repository -y ppa:cassou/emacs &&
+        sudo apt-get update -qq &&
+        sudo apt-get install -qq emacs24 emacs24-el;
+    fi
+
+script: cd test && bash .travis.sh

--- a/ensime-client.el
+++ b/ensime-client.el
@@ -170,15 +170,14 @@ overrides `ensime-buffer-connection'.")
 
 (defun ensime-proc-if-alive (proc)
   "Returns proc if proc's buffer is alive, otherwise returns nil."
-  (when (and proc (buffer-live-p (process-buffer proc))) proc))
+  (when (and proc (ensime-connected-p proc)) proc))
 
 (defun ensime-connected-p (&optional conn)
-  "Return t if ensime-current-connection would return non-nil.
- Return nil otherwise."
+  "Return t if there is a valid, active connection."
   (let ((conn (or conn (ensime-current-connection))))
     (and conn
-     (buffer-live-p (process-buffer conn)))))
-
+	 (buffer-live-p (process-buffer conn))
+	 (eq (process-status conn) 'open))))
 
 (defun ensime-connection ()
   "Return the connection to use for Lisp interaction.

--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -550,11 +550,17 @@ currently open in emacs."
 	(let* ((dest (cond ((stringp f) f)
 			   ((listp f) (car f))))
 	       (src (cond ((stringp f) f)
-			  ((listp f) (cadr f))))
-	       (do-visit (equal dest src)))
+			  ((listp f) (cadr f)))))
 	  (when-let (buf (find-buffer-visiting dest))
                     (with-current-buffer buf
-                      (insert-file-contents src do-visit nil nil t)
+		      (insert-file-contents src nil nil nil t)
+		      ;; Rather than pass t to 'visit' the file by way of
+		      ;; insert-file-contents, we manually clear the
+		      ;; modification flags. This way the buffer-file-name
+		      ;; is untouched.
+		      (when (equal dest src)
+			(clear-visited-file-modtime)
+			(set-buffer-modified-p nil))
                       (when typecheck
                         (ensime-typecheck-current-file)))))))
     (goto-char pt)))

--- a/test/.travis.sh
+++ b/test/.travis.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+export ENSIME_RUN_AND_EXIT=1
+export DISPLAY=:99.0
+sh -e /etc/init.d/xvfb start
+sleep 3
+$EMACS --version
+$EMACS -d :99 --no-init-file --load dotemacs_test.el --eval "(ensime-run-all-tests)"
+

--- a/test/dotemacs_test.el
+++ b/test/dotemacs_test.el
@@ -1,3 +1,11 @@
+(defadvice message (before ensime-log-to-file (format-string &rest args))
+  (let ((text (when format-string
+		(format "%s\n" (apply 'format format-string args)))))
+    (princ text 'external-debugging-output)
+    text))
+
+(ad-activate 'message)
+
 (setq user-emacs-directory (expand-file-name "./emacs.d"))
 (require 'package)
 (add-to-list 'package-archives
@@ -6,7 +14,8 @@
   (add-to-list 'package-archives '("gnu" . "http://elpa.gnu.org/packages/")))
 (package-initialize)
 (require 'cl)
-(let ((needed-packages '(s dash popup auto-complete scala-mode2 sbt-mode)))
+(let ((needed-packages '(s dash popup auto-complete
+			   scala-mode2 sbt-mode yasnippet company)))
   (unless (every #'package-installed-p needed-packages)
     (package-refresh-contents)
     (dolist (p needed-packages)
@@ -19,6 +28,7 @@
 (require 'ensime-test)
 (setq ensime-test-dev-home (expand-file-name "../"))
 (message "Using ensime-test-dev-home of %s" ensime-test-dev-home)
+(add-hook 'scala-mode-hook 'ensime-scala-mode-hook)
 
 (setq inhibit-startup-message t)
 (setq debug-on-error nil)

--- a/test/run_emacs_tests.sh
+++ b/test/run_emacs_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export ENSIME_RUN_AND_EXIT=1
+
 if [ $# -ge 1 ]; then
   emacs --no-init-file --load ./dotemacs_test.el --eval '(ensime-run-one-test "'"$*"'")'
 else


### PR DESCRIPTION
Fixes two tests that were consistently failing on OSX:

 1 - "Test rename refactoring over multiple files."
This test was failing for reasons detailed in issue #710. My fix is small and localized, leaving the larger question of canonicalization for another pass. In any case, I think it's reasonable that reverting a buffer should not alter buffer-file-name.

 2 - "Test deleting file and reloading."
This test was hanging because the (find-file...) call was not triggering a typecheck as it should have, because the ensime minor mode was not engaged. Added the hook in the startup script. (Was this passing on linux/windows?)

All (enabled)integrations passing for me now.
