### PR TITLE
Jump to correct line from stacktrace

### DIFF
--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -317,12 +317,13 @@ Used for determining the default in the next one.")
       (setq scala-type (replace-regexp-in-string "\\$" "" scala-type ))
       (setq info (ensime-rpc-get-type-by-name scala-type)))
     (when (and info (plist-get info :pos))
-      (let ((pos (list* :line line (plist-get info :pos))))
+      (let* ((symbol-pos (plist-get info :pos))
+             (button-pos (list :line line :file (plist-get symbol-pos :file))))
         (make-text-button link-start link-end
                           'help-echo "mouse-1, RET: go to source"
                           'follow-link t
                           'action `(lambda (ignore)
-                                     (ensime-goto-source-location ',pos t)))))))
+                                     (ensime-goto-source-location ',button-pos t)))))))
 
 (provide 'ensime-inf)
 


### PR DESCRIPTION
Fix ensime/ensime-server#688. This broke when I made a change whereby :offset would take precedence over :line when jumping to a position. It used to be the other way around.
