### PR TITLE
Cleanup elisp connection accessors (resolves ensime/ensime-server#718)

### DIFF
--- a/ensime-auto-complete.el
+++ b/ensime-auto-complete.el
@@ -75,31 +75,6 @@
     ))
 
 
-(defmacro* ensime-ac-with-buffer-copy (&rest body)
-  "Create a duplicate of the current buffer, copying all contents.
-Bind ensime-buffer-connection and buffer-file-name to the given values.
-Execute forms in body in the context of this new buffer. The idea is that
-we can abuse this buffer, even saving its contents to disk, and all the
-changes will be forgotten."
-  `(let ((buf (current-buffer))
-	 (file-name buffer-file-name)
-	 (p (point))
-	 (conn (ensime-current-connection)))
-
-     (unwind-protect
-	 (with-temp-buffer
-	   (let ((ensime-buffer-connection conn)
-		 (buffer-file-name file-name))
-	     (insert-buffer-substring buf)
-	     (goto-char p)
-	     ,@body
-	     ))
-       ;; Make sure we overwrite any changes
-       ;; written from temp buffer.
-       (ensime-write-buffer nil t)
-       )))
-
-
 (defun ensime-ac-trunc-summary (str)
   (let ((len (length str)))
     (if (> len 40)

--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -117,7 +117,7 @@ server."
   "Run a Scala interpreter in an Emacs buffer"
   (interactive)
 
-  (let ((conn (or (ensime-current-connection)
+  (let ((conn (or (ensime-connection-or-nil)
 		  (ensime-prompt-for-connection)))
 	(root-path (or (ensime-configured-project-root) "."))
 	(cmd-and-args (ensime-inf-get-repl-cmd-line)))

--- a/ensime-inspector.el
+++ b/ensime-inspector.el
@@ -338,10 +338,8 @@ interface we are implementing."
       ))))
 
 (defun ensime-completing-read-path (prompt &optional initial)
-  ;; Note: First thing we do is bind buffer connection so
-  ;; completion function will have access.
-  (let ((ensime-dispatching-connection
-	 (ensime-current-connection)))
+  ;; Bind buffer connection so completion function will have access.
+  (let ((ensime-dispatching-connection (ensime-connection)))
     (completing-read prompt #'ensime-path-completions
 		     nil nil (or initial (ensime-package-containing-point)))))
 

--- a/ensime-macros.el
+++ b/ensime-macros.el
@@ -24,7 +24,7 @@
 (defmacro ensime-with-conn-interactive (conn-sym &rest body)
   "Surround body forms with a check to see if we're connected.
 If not, message the user."
-  `(let* ((,conn-sym (or (ensime-current-connection)
+  `(let* ((,conn-sym (or (ensime-connection-or-nil)
 			 (ensime-prompt-for-connection))))
      (if conn
 	 (progn ,@body)
@@ -62,13 +62,6 @@ buffer is created, for example to set the major mode.
 	 (setq buffer-read-only t)
 	 (set-window-point (ensime-display-popup-buffer ,(or select 'nil))
 			   (point))))))
-
-(defmacro ensime-assert-connected (&rest body)
-  "Surround body forms with a check to see if we're connected.
-If not, message the user."
-  `(if (ensime-connected-p)
-       (progn ,@body)
-     (message "This command requires a connection to an ENSIME server.")))
 
 (defmacro ensime-assert-buffer-saved-interactive (&rest body)
   "Offer to save buffer if buffer is modified. Execute body only if

--- a/ensime-model.el
+++ b/ensime-model.el
@@ -126,10 +126,9 @@
 (defun ensime-member-pos (member)
   (plist-get member :pos))
 
-
 (defun ensime-source-jars-dir ()
   (when (ensime-connected-p)
-    (let ((config (ensime-config (ensime-current-connection))))
+    (let ((config (ensime-config (ensime-connection))))
       (plist-get config :source-jars-dir))))
 
 (defun ensime-pos-file (pos)

--- a/ensime-notes.el
+++ b/ensime-notes.el
@@ -117,10 +117,10 @@ any buffer visiting the given file."
 
 
 (defun ensime-refresh-all-note-overlays ()
-  (let ((notes (if (ensime-connected-p)
+  (let ((notes (when (ensime-connected-p)
 		   (append
-		    (ensime-java-compiler-notes (ensime-current-connection))
-		    (ensime-scala-compiler-notes (ensime-current-connection)))
+		    (ensime-java-compiler-notes (ensime-connection))
+		    (ensime-scala-compiler-notes (ensime-connection)))
 		 )))
     (ensime-clear-note-overlays)
     (ensime-make-note-overlays notes)
@@ -202,7 +202,7 @@ any buffer visiting the given file."
 
 (defun ensime-goto-next-note (forward)
   "Helper to move point to next note. Go forward if forward is non-nil."
-  (let* ((conn (ensime-current-connection))
+  (let* ((conn (ensime-connection))
 	 (notes (append (ensime-java-compiler-notes conn)
 			(ensime-scala-compiler-notes conn)))
 	 (next-note (ensime-next-note-in-current-buffer notes forward)))

--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -95,10 +95,9 @@
 
 (defun ensime-sem-high-refresh-all-buffers ()
   (interactive)
-  (let ((conn (ensime-current-connection)))
-    (let ((bufs (ensime-connection-visiting-buffers conn)))
-      (dolist (buf bufs)
-	(ensime-sem-high-refresh-buffer buf)))))
+  (let ((bufs (ensime-connection-visiting-buffers (ensime-connection))))
+    (dolist (buf bufs)
+      (ensime-sem-high-refresh-buffer buf))))
 
 (defun ensime-sem-high-refresh-region (beg end)
   "Refresh semantic highlighting for the given region."


### PR DESCRIPTION
Note, there are a few places we were previously propagating nil and are now raising an error.
Also fix a recent bug I introduced where ensime-proc-if-alive would return wrong results for non-connection processes.
Also remove a bit of dead code.
