### PR TITLE
Remove extra dash in ensime--parent-dir

### DIFF
--- a/ensime-util.el
+++ b/ensime-util.el
@@ -79,10 +79,6 @@
 
 ;; File/path functions
 
-(defun ensime-parent-dir (dir)
-  (unless (equal "/" dir)
-    (file-name-directory (directory-file-name dir))))
-
 (defun ensime-source-file-p (&optional filename)
   "Return t if the given filename (or the currently visited file if no
 argument is supplied) is a .scala or .java file."

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -68,14 +68,18 @@
   :type '(repeat string)
   :group 'ensime-server)
 
+(defun ensime--parent-dir (dir)
+  (unless (equal "/" dir)
+    (file-name-directory (directory-file-name dir))))
+
 (defcustom ensime-default-java-home
   (cond ((getenv "JDK_HOME"))
-	((getenv "JAVA_HOME"))
-	((file-exists-p "/usr/libexec/java_home")
-	 (s-chomp (shell-command-to-string "/usr/libexec/java_home")))
-	('t (let ((java (file-truename (executable-find "javac"))))
-	      (warn "JDK_HOME and JAVA_HOME are not set, inferring from %s" java)
-	      (ensime--parent-dir (ensime--parent-dir java)))))
+        ((getenv "JAVA_HOME"))
+        ((file-exists-p "/usr/libexec/java_home")
+         (s-chomp (shell-command-to-string "/usr/libexec/java_home")))
+        ('t (let ((java (file-truename (executable-find "javac"))))
+              (warn "JDK_HOME and JAVA_HOME are not set, inferring from %s" java)
+              (ensime--parent-dir (ensime--parent-dir java)))))
   "Location of the JDK's base directory"
   :type 'string
   :group 'ensime-server)


### PR DESCRIPTION
Remove a couple of calls to `ensime--parent-dir`, which are only hit as a last resort when various parts of the java environment are wrong. Update to `ensime-parent-dir` as defined in `ensime-utils.el` instead.