### PR TITLE
Indent region if mark is active

### DIFF
--- a/ensime-company.el
+++ b/ensime-company.el
@@ -108,7 +108,9 @@
   (interactive)
   (when (or (ensime-at-bol-p)
 	    (not (ensime--company-try-completion)))
-    (indent-according-to-mode)))
+    (if mark-active
+        (indent-region (region-beginning) (region-end))
+      (indent-according-to-mode))))
 
 (defun ensime-company-enable ()
   (set (make-local-variable 'company-backends) '(ensime-company))


### PR DESCRIPTION
This allows the use of the `tab` key to indent a marked region. Otherwise, we indent the current line.