### PR TITLE
Fix race condition when server is started but not ready

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -84,29 +84,17 @@ This is automatically synchronized from Lisp.")
 (ensime-def-connection-var ensime-protocol-version nil
   "The protocol version used on the connection.")
 
-(ensime-def-connection-var ensime-server-implementation-type nil
-  "The implementation type of the Lisp process.")
-
 (ensime-def-connection-var ensime-server-implementation-version nil
   "The implementation type of the Lisp process.")
 
 (ensime-def-connection-var ensime-server-implementation-name nil
   "The short name for the Lisp implementation.")
 
-(ensime-def-connection-var ensime-server-implementation-program nil
-  "The argv[0] of the process running the Lisp implementation.")
-
 (ensime-def-connection-var ensime-connection-name nil
   "The short name for connection.")
 
 (ensime-def-connection-var ensime-config nil
   "The project configuration corresponding to this connection.")
-
-(ensime-def-connection-var ensime-communication-style nil
-  "The communication style.")
-
-(ensime-def-connection-var ensime-machine-instance nil
-  "The name of the (remote) machine running the Lisp process.")
 
 (ensime-def-connection-var ensime-analyzer-ready nil
   "Whether the analyzer has finished its initial run.")
@@ -294,6 +282,12 @@ This doesn't mean it will connect right after Ensime is loaded."
   "Make a connection out of PROCESS."
   (let ((ensime-dispatching-connection process))
 
+    (setf (ensime-protocol-version process) nil
+          (ensime-pid process) nil
+          (ensime-server-implementation-name) nil
+          (ensime-connection-name) nil
+          (ensime-analyzer-ready nil))
+
     ;; Initialize connection state in the process-buffer of PROC."
 
     ;; To make life simpler for the user: if this is the only open
@@ -318,11 +312,9 @@ This doesn't mean it will connect right after Ensime is loaded."
          (y-or-n-p "Close old connections first? "))
     (ensime-disconnect-all))
   (message "Connecting to Swank on port %S.." port)
-  (let ()
-    (message "Connecting to Swank on port %S.." port)
-    (let* ((process (ensime-net-connect host port))
-       (ensime-dispatching-connection process))
-      (ensime-setup-connection process))))
+  (let* ((process (ensime-net-connect host port))
+         (ensime-dispatching-connection process))
+    (ensime-setup-connection process)))
 
 
 (defun ensime-handle-connection-info (connection info)
@@ -404,9 +396,9 @@ This doesn't mean it will connect right after Ensime is loaded."
 
 (defun ensime-draw-connection-list ()
   (let ((default-pos nil)
-	(fstring "%s%2s  %-10s  %-17s  %-7s %-s\n"))
-    (insert (format fstring " " "Nr" "Name" "Port" "Pid" "Type")
-	    (format fstring " " "--" "----" "----" "---" "----"))
+	(fstring "%s%2s  %-10s  %-17s  %-7s\n"))
+    (insert (format fstring " " "Nr" "Name" "Port" "Pid")
+	    (format fstring " " "--" "----" "----" "---"))
     (dolist (p (reverse ensime-net-processes))
       (ensime-insert-propertized
        (list 'ensime-connection p)
@@ -415,9 +407,7 @@ This doesn't mean it will connect right after Ensime is loaded."
 	       (ensime-connection-number p)
 	       (ensime-connection-name p)
 	       (or (process-id p) (process-contact p))
-	       (ensime-pid p)
-	       (ensime-server-implementation-type p))))
-    ))
+	       (ensime-pid p))))))
 
 
 

--- a/ensime-company.el
+++ b/ensime-company.el
@@ -189,7 +189,7 @@
 
     (`candidates
      ;; Just ignore if there's no connection.
-     (when (ensime-connected-p)
+     (when (and (ensime-connected-p) (ensime-analyzer-ready))
        (let ((max-results 1000000)  ;; We want *all* candidates.
 	     (case-sense nil))
 	 `(:async . (lambda (callback)

--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -150,7 +150,7 @@ server."
 (defun ensime-inf-get-repl-cmd-line ()
   "Get the command needed to launch a repl, including all
 the current project's dependencies. Returns list of form (cmd [arg]*)"
-  (if (ensime-connected-p)
+  (if (and (ensime-connected-p) (ensime-analyzer-ready))
       (ensime-replace-keywords
        ensime-inf-cmd-template
        (ensime-rpc-repl-config))

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -13,21 +13,23 @@
 
 (defun ensime-run-after-save-hooks ()
   "Things to run whenever a source buffer is saved."
-  (condition-case err-info
-      (run-hooks 'ensime-source-buffer-saved-hook)
-    (error
-     (message
-      "Error running ensime-source-buffer-saved-hook: %s"
-      err-info))))
+  (when (and (ensime-connected-p) (ensime-analyzer-ready))
+    (condition-case err-info
+        (run-hooks 'ensime-source-buffer-saved-hook)
+      (error
+       (message
+        "Error running ensime-source-buffer-saved-hook: %s"
+        err-info)))))
 
 (defun ensime-run-find-file-hooks ()
   "Things to run whenever a source buffer is opened."
-  (condition-case err-info
-      (run-hooks 'ensime-source-buffer-loaded-hook)
-    (error
-     (message
-      "Error running ensime-source-buffer-loaded-hook: %s"
-      err-info))))
+  (when (and (ensime-connected-p) (ensime-analyzer-ready))
+    (condition-case err-info
+        (run-hooks 'ensime-source-buffer-loaded-hook)
+      (error
+       (message
+        "Error running ensime-source-buffer-loaded-hook: %s"
+        err-info)))))
 
 (defun ensime-save-buffer-no-hooks ()
   "Just save the buffer per usual, don't type-check!"
@@ -338,6 +340,7 @@
   (when (and (eventp event)
              ensime-mode
              (ensime-connected-p)
+             (ensime-analyzer-ready)
              (posn-point (event-end event)))
 
     (let* ((point (posn-point (event-end event)))
@@ -514,7 +517,8 @@
 
 (defun ensime-idle-typecheck-function ()
   (when (and ensime-typecheck-when-idle
-             (ensime-connected-p))
+             (ensime-connected-p)
+             (ensime-analyzer-ready))
     (let* ((now (float-time))
            (last-typecheck (ensime-last-typecheck-run-time (ensime-connection)))
            (earliest-allowed-typecheck (+ last-typecheck ensime-typecheck-interval)))

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1482,7 +1482,8 @@
                      :contents ,(ensime-test-concat-lines
                                  "class HelloWorld{"
                                  "def foo:Int=1"
-                                 "}"))))))
+                                 "}"
+                                 ""))))))
       (ensime-test-init-proj proj))
 
     ((:connected connection-info))
@@ -1514,7 +1515,8 @@
         (ensime-assert-equal src (ensime-test-concat-lines
                                   "class HelloWorld {"
                                   "  def foo: Int = 1"
-                                  "}")))
+                                  "}"
+                                  "")))
 
       (ensime-test-cleanup proj))))
 


### PR DESCRIPTION
Fix ensime/ensime-server#806.

The earliest time to safely send rpc commands is after receiving the
connection info that includes the protcol version. But it turns out that
most rpc commands don't work until the analyzer is ready so we wait
for that.