### PR TITLE
Report coverage to coveralls.io using undercover

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
         sudo apt-get install -qq emacs24 emacs24-el;
     fi
 
-script: cd test && bash .travis.sh
+script: bash test/.travis.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=239449)](https://www.bountysource.com/trackers/239449-ensime?utm_source=239449&utm_medium=shield&utm_campaign=TRACKER_BADGE)
 [![Build Status](https://travis-ci.org/ensime/ensime-emacs.svg?branch=master)](https://travis-ci.org/ensime/ensime-emacs)
+[![Coverage Status](https://coveralls.io/repos/ensime/ensime-emacs/badge.svg?branch=coveralls)](https://coveralls.io/r/ensime/ensime-emacs?branch=coveralls)
 [![Melpa Status](http://melpa.milkbox.net/packages/ensime-badge.svg)](http://melpa.milkbox.net/#/ensime)
 
 

--- a/test/.travis.sh
+++ b/test/.travis.sh
@@ -5,5 +5,5 @@ export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 sleep 3
 $EMACS --version
-$EMACS -d :99 --no-init-file --load dotemacs_test.el --eval "(ensime-run-all-tests)"
+$EMACS -d :99 --no-init-file --load test/dotemacs_test.el --eval "(ensime-run-all-tests)"
 

--- a/test/dotemacs_test.el
+++ b/test/dotemacs_test.el
@@ -36,7 +36,7 @@
 (condition-case err
     (let* ((pkg-info
 	    (with-temp-buffer
-	      (insert-file-contents "../ensime-pkg.el")
+	      (insert-file-contents "ensime-pkg.el")
 	      (goto-char (point-min))
 	      (read (current-buffer))))
 	   (name (cadr pkg-info))
@@ -55,10 +55,16 @@
 	    ))))
   (error (message "Error loading dependencies: %s" err)))
 
-(add-to-list 'load-path "../")
+(when (getenv "TRAVIS")
+  (unless (package-installed-p 'undercover)
+    (package-install 'undercover))
+  (when (require 'undercover nil t)
+    (undercover "ensime*.el" (:exclude "ensime-client.el" "ensime-startup.el"))))
+
+(add-to-list 'load-path "./")
 (require 'ensime)
 (require 'ensime-test)
-(setq ensime-test-dev-home (expand-file-name "../"))
+(setq ensime-test-dev-home (expand-file-name "./"))
 (setq ensime-log-events t)
 (setq ensime-typecheck-when-idle nil)
 (message "Using ensime-test-dev-home of %s" ensime-test-dev-home)


### PR DESCRIPTION
Addresses https://github.com/ensime/ensime-server/issues/448 , although doesn't test ensime-client.el or ensime-startup.el due to issues described in my reply to https://github.com/ensime/ensime-server/issues/448 .

To set this up:

1. Enable ensime/ensime-server on coveralls.io.
2. Merge the pull request.

Travis should test the merged pull request, then it should report to coveralls.io (about 38%). I've included the badge in README.md, so that should work after you set that up.

Hope this helps!