### PR TITLE
Fixes https://github.com/ensime/ensime-server/issues/769 (can see ENSIME...

### DIFF
--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -220,7 +220,6 @@ CACHE-DIR is the server's persistent output directory."
            (java-command (concat java-home "bin/java"))
            (args (-flatten (list
                             "-classpath" classpath
-                            "-Dscala.usejavacp=true"
                             flags
                             (concat "-Densime.config=" (expand-file-name config-file))
                             "org.ensime.server.Server"))))


### PR DESCRIPTION
...-server classpath in completion options)

Problem is properties set on the command-line override the setting we instantiate the presentation compiler with. And since after testing with scala 2.9, 2.10 and 2.11 without this property didn't seem to affect Ensime, we're killing it.