### PR TITLE
Fixes ensime/ensime-server#815: close refactoring buffer after close.

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -1172,7 +1172,12 @@ with the current project's dependencies loaded. Returns a property list."
   (ensime-eval-async `(swank:exec-refactor ,proc-id , refactor-type) continue))
 
 (defun ensime-rpc-refactor-cancel (proc-id)
-  (ensime-eval-async `(swank:cancel-refactor ,proc-id) #'identity))
+  ;(ensime-eval-async `(swank:cancel-refactor ,proc-id) #'identity))
+  (ensime-eval-async
+   `(swank:cancel-refactor ,proc-id)
+   (lambda (result)
+     (kill-buffer ensime-refactor-info-buffer-name)
+     result)))
 
 
 (defun ensime-rpc-shutdown-server ()

--- a/ensime-refactor.el
+++ b/ensime-refactor.el
@@ -188,7 +188,8 @@
 (defun ensime-refactor-handle-result (result)
   (let ((touched (plist-get result :touched-files)))
     (ensime-revert-visited-files touched t)
-    (ensime-event-sig :refactor-done touched)))
+    (ensime-event-sig :refactor-done touched)
+    (kill-buffer ensime-refactor-info-buffer-name)))
 
 (defun ensime-refactor-populate-confirmation-buffer (refactor-type changes)
   (let ((header


### PR DESCRIPTION
Note other 'popup' buffers not related to refactoring also suffer from this, but this commit only addresses those for refactoring