### PR TITLE
Auto-generate .ensime

### DIFF
--- a/ensime-util.el
+++ b/ensime-util.el
@@ -128,7 +128,7 @@ argument is supplied) is a .scala or .java file."
 (defun ensime-temp-file-name (name)
   "Return the path of a temp file with filename 'name'."
   (expand-file-name
-   (concat (file-name-as-directory (ensime-temp-directory)) name)))
+   (ensime--join-paths (ensime-temp-directory name))))
 
 ; TODO deprecate and rewrite callers to use the cache-dir
 (defun ensime-temp-directory ()
@@ -146,11 +146,6 @@ argument is supplied) is a .scala or .java file."
 				      buffer-file-name)))))
      (ensime-write-buffer ,file-sym)
      ,@body))
-
-(defmacro ensime-with-temp-file (name)
-  "Return the path of a temp file with filename 'name'."
-  (concat (file-name-as-directory (ensime-temp-directory))
-	  name))
 
 (defun ensime-assert-executable-on-path (name)
   (when (null (executable-find name))
@@ -194,6 +189,22 @@ Do not show 'Writing..' message."
   (with-temp-buffer
     (insert-file-contents filename)
     (buffer-string)))
+
+(defun ensime--dependencies-newer-than-target-p (target-file dep-files-list)
+  (if (file-exists-p target-file)
+      (let ((target-mtime (nth 5 (file-attributes target-file))))
+        (some (lambda (d)
+                (time-less-p target-mtime (nth 5 (file-attributes d))))
+              dep-files-list))
+    t))
+
+(defun ensime--join-paths (base &rest paths)
+  (if paths
+      (apply
+       'ensime--join-paths
+       (concat (file-name-as-directory base) (first paths))
+       (rest paths))
+    base))
 
 ;; Commonly used functions
 

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -63,6 +63,13 @@
   :type 'string
   :group 'ensime-server)
 
+(defcustom ensime-auto-generate-config nil
+  "If true, ENSIME will try to create a config file automatically, and
+update it when the project definition changes. At the moment, this only
+works for sbt projects."
+  :type 'boolean
+  :group 'ensime-ui)
+
 (defcustom ensime-server-version "0.9.10-SNAPSHOT"
   "Distributed version of the server to upgrade and start.
 This is primarily useful for ENSIME developers (or bug reporters)

--- a/ensime.el
+++ b/ensime.el
@@ -95,7 +95,12 @@
    ENSIME server and connect to its Swank server."
   (interactive)
   (condition-case ex
-      (ensime--maybe-update-and-start)
+      (if ensime-auto-generate-config
+          (ensime--maybe-refresh-config
+           nil
+           'ensime--maybe-update-and-start
+           '(lambda (reason) (ensime--maybe-update-and-start)))
+        (ensime--maybe-update-and-start))
     ('error (error (format
                     "check that sbt is on your PATH and that your config is compatible with %s [%s]"
                     "http://github.com/ensime/ensime-server/wiki/Example-Configuration-File" ex)))))
@@ -104,7 +109,12 @@
 (defun ensime-remote (host port)
   "Read config file for settings. Then connect to an existing ENSIME server."
   (interactive "shost: \nnport: ")
-  (ensime--maybe-update-and-start (url-gateway-nslookup-host host) port))
+
+  (if ensime-auto-generate-config
+      (ensime--maybe-refresh-config
+       nil
+       `(lambda () (ensime--maybe-update-and-start (url-gateway-nslookup-host ,host) ,port))
+       `(lambda (reason) (ensime--maybe-update-and-start (url-gateway-nslookup-host ,host) ,port)))))
 
 (provide 'ensime)
 


### PR DESCRIPTION
Fix ensime/ensime-server#773.   When an sbt project is detected, run
"sbt gen-ensime" before startup.  Feature is off by default and
controlled by 'ensime-auto-generate-config'

Fix ensime/ensime-server#695