### PR TITLE
Allow elisp to be byte compiled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .#*
 *.*#
+*~
 
 TAGS
 emacs.d
+*.elc

--- a/ensime-auto-complete.el
+++ b/ensime-auto-complete.el
@@ -19,7 +19,12 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
 (require 'ensime-completion-util)
+(require 'ensime-model)
+(require 'ensime-util)
 (require 'auto-complete)
 
 (defcustom ensime-ac-enable-argument-placeholders t
@@ -251,6 +256,5 @@ be used later to give contextual help when entering arguments."
 (provide 'ensime-auto-complete)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-comint-utils.el
+++ b/ensime-comint-utils.el
@@ -19,6 +19,10 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (require 'comint)
 
 (defvar ensime-comint-filter-buffer " *ensime-comint-filter-buffer*"
@@ -48,7 +52,7 @@ the output received after a call to `ensime-comint-complete'.")
          (cand-max-length
           (+ 1 (apply 'max (mapcar 'length candidates))))
          (nbr-cols (/ wwidth cand-max-length)))
-    (mapcar '(lambda (cand)
+    (mapcar #'(lambda (cand)
                (ensime-comint-shape-candidate
                 cand cand-max-length nbr-cols candidates))
             candidates)))
@@ -129,6 +133,5 @@ the output received after a call to `ensime-comint-complete'.")
 (provide 'ensime-comint-utils)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-company.el
+++ b/ensime-company.el
@@ -19,10 +19,18 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (require 'ensime-completion-util)
+(require 'ensime-util)
 (require 'company)
 (require 'yasnippet)
 (require 'scala-mode2-syntax)
+(require 'auto-complete)
+(require 's)
+(require 'dash)
 
 (defcustom ensime-company-case-sensitive nil
   "If non-nil, omit completions that don't match the case of prefix."
@@ -226,5 +234,4 @@
 (provide 'ensime-company)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime-completion-util.el
+++ b/ensime-completion-util.el
@@ -19,27 +19,11 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (require 'scala-mode2-syntax)
-
-(defun ensime--annotate-completions (completions)
-  "Maps plist structures to propertized strings that will survive
- being passed through the innards of auto-complete or company."
-  (mapcar
-   (lambda (m)
-     (let* ((type-sig (plist-get m :type-sig))
-	    (type-id (plist-get m :type-id))
-	    (is-callable (plist-get m :is-callable))
-	    (to-insert (plist-get m :to-insert))
-	    (name (plist-get m :name))
-	    (candidate name))
-       (propertize candidate
-		   'symbol-name name
-		   'type-sig type-sig
-		   'type-id type-id
-		   'is-callable is-callable
-		   'to-insert to-insert
-		   ))) completions))
-
 
 ;; In order to efficiently and accurately match completion prefixes, we construct
 ;; a regular expression which matches scala identifiers in reverse.
@@ -73,6 +57,26 @@
 	  scala-syntax:letterOrDigit-group
 	  scala-syntax:opchar-group
 	  "]"))
+
+(defun ensime--annotate-completions (completions)
+  "Maps plist structures to propertized strings that will survive
+ being passed through the innards of auto-complete or company."
+  (mapcar
+   (lambda (m)
+     (let* ((type-sig (plist-get m :type-sig))
+	    (type-id (plist-get m :type-id))
+	    (is-callable (plist-get m :is-callable))
+	    (to-insert (plist-get m :to-insert))
+	    (name (plist-get m :name))
+	    (candidate name))
+       (propertize candidate
+		   'symbol-name name
+		   'type-sig type-sig
+		   'type-id type-id
+		   'is-callable is-callable
+		   'to-insert to-insert
+		   ))) completions))
+
 
 (defun ensime-completion-prefix-at-point ()
   "Returns the prefix to complete."
@@ -150,5 +154,4 @@
 (provide 'ensime-completion-util)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime-config.el
+++ b/ensime-config.el
@@ -20,7 +20,11 @@
 ;;     MA 02111-1307, USA.
 
 
-(eval-and-compile (require 'ensime-macros))
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
+(require 'dash)
 
 (defvar ensime-config-file-name ".ensime"
   "The default file name for ensime project configurations.")
@@ -46,9 +50,6 @@
 				(list dir)))))))
       (-first (lambda (dir) (ensime-path-includes-dir-p file dir))
 	      source-roots))))
-
-(defmacro ensime-set-key (conf key val)
-  `(setq ,conf (plist-put ,conf ,key ,val)))
 
 (defun ensime-config-find-file (file-name)
   "Search up the directory tree starting at file-name
@@ -186,6 +187,5 @@ only sbt projects are supported."
 (provide 'ensime-config)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-doc.el
+++ b/ensime-doc.el
@@ -19,6 +19,10 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (defun ensime-make-doc-url (type &optional member)
   "Given a type and an optional member object, yields an http url for
  browsing the documentation for those objects."
@@ -35,6 +39,5 @@
 
 (provide 'ensime-doc)
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-goto-testfile.el
+++ b/ensime-goto-testfile.el
@@ -1,5 +1,9 @@
 ;;; ensime-goto-testfile.el  -- Navigate to test classes
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (require 'scala-mode2-syntax)
 
 (defun ensime-goto-test (&optional other-window-p)
@@ -321,5 +325,4 @@ class %TESTCLASS% extends Specification {
 (provide 'ensime-goto-testfile)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -51,10 +51,11 @@
 ;;; Code
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(provide 'ensime-inf)
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
 
 (require 'comint)
-
 
 (defgroup ensime-inf nil
   "Support for running scala as an inferior process."
@@ -79,6 +80,11 @@ server."
   :type 'boolean)
 
 (defconst ensime-inf-buffer-name "*ensime-inferior-scala*")
+
+(defvar ensime-inf-prev-l/c-dir/file nil
+  "Caches the last (directory . file) pair.
+Caches the last pair used in the last ensime-inf-load-file.
+Used for determining the default in the next one.")
 
 
 (define-derived-mode ensime-inf-mode comint-mode "ENSIME Inferior Scala"
@@ -238,11 +244,6 @@ the current project's dependencies. Returns list of form (cmd [arg]*)"
   (interactive)
   (ensime-inf-eval-region (point-min) (point-max)))
 
-(defvar ensime-inf-prev-l/c-dir/file nil
-  "Caches the last (directory . file) pair.
-Caches the last pair used in the last ensime-inf-load-file.
-Used for determining the default in the next one.")
-
 (defun ensime-inf-load-file (file-name)
   "Load a file in the Scala interpreter."
   (interactive (comint-get-source "Load Scala file: " ensime-inf-prev-l/c-dir/file
@@ -328,6 +329,5 @@ Used for determining the default in the next one.")
 (provide 'ensime-inf)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -1,52 +1,14 @@
 ;;; ensime-mode.el --- ensime mode
 
-;;;;; ensime-mode
-(defun ensime-scala-mode-hook ()
-  "Conveniance hook function that just starts ensime-mode."
-  (ensime-mode 1))
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
 
 (defvar ensime-source-buffer-saved-hook nil
   "Hook called whenever an ensime source buffer is saved.")
 
 (defvar ensime-source-buffer-loaded-hook nil
   "Hook called whenever an ensime source buffer is loaded.")
-
-(defun ensime-run-after-save-hooks ()
-  "Things to run whenever a source buffer is saved."
-  (when (and (ensime-connected-p) (ensime-analyzer-ready))
-    (condition-case err-info
-        (run-hooks 'ensime-source-buffer-saved-hook)
-      (error
-       (message
-        "Error running ensime-source-buffer-saved-hook: %s"
-        err-info)))))
-
-(defun ensime-run-find-file-hooks ()
-  "Things to run whenever a source buffer is opened."
-  (when (and (ensime-connected-p) (ensime-analyzer-ready))
-    (condition-case err-info
-        (run-hooks 'ensime-source-buffer-loaded-hook)
-      (error
-       (message
-        "Error running ensime-source-buffer-loaded-hook: %s"
-        err-info)))))
-
-(defun ensime-save-buffer-no-hooks ()
-  "Just save the buffer per usual, don't type-check!"
-  (let ((after-save-hook nil)
-        (before-save-hook nil))
-    (save-buffer)))
-
-(defun ensime-delete-buffer-and-file ()
-  "Kill the current buffer and delete the corresponding file!"
-  (interactive)
-  (ensime-assert-buffer-saved-interactive
-   (let ((f buffer-file-name))
-     (ensime-rpc-remove-file f)
-     (delete-file f)
-     (kill-buffer nil)
-     )))
-
 
 (defvar ensime-mode-map
   (let ((map (make-sparse-keymap)))
@@ -139,6 +101,47 @@
     map)
   "Keymap for ENSIME mode."
   )
+
+;;;;; ensime-mode
+(defun ensime-scala-mode-hook ()
+  "Conveniance hook function that just starts ensime-mode."
+  (ensime-mode 1))
+
+(defun ensime-run-after-save-hooks ()
+  "Things to run whenever a source buffer is saved."
+  (when (and (ensime-connected-p) (ensime-analyzer-ready))
+    (condition-case err-info
+        (run-hooks 'ensime-source-buffer-saved-hook)
+      (error
+       (message
+        "Error running ensime-source-buffer-saved-hook: %s"
+        err-info)))))
+
+(defun ensime-run-find-file-hooks ()
+  "Things to run whenever a source buffer is opened."
+  (when (and (ensime-connected-p) (ensime-analyzer-ready))
+    (condition-case err-info
+        (run-hooks 'ensime-source-buffer-loaded-hook)
+      (error
+       (message
+        "Error running ensime-source-buffer-loaded-hook: %s"
+        err-info)))))
+
+(defun ensime-save-buffer-no-hooks ()
+  "Just save the buffer per usual, don't type-check!"
+  (let ((after-save-hook nil)
+        (before-save-hook nil))
+    (save-buffer)))
+
+(defun ensime-delete-buffer-and-file ()
+  "Kill the current buffer and delete the corresponding file!"
+  (interactive)
+  (ensime-assert-buffer-saved-interactive
+   (let ((f buffer-file-name))
+     (ensime-rpc-remove-file f)
+     (delete-file f)
+     (kill-buffer nil)
+     )))
 
 (easy-menu-define ensime-mode-menu ensime-mode-map
   "Menu for ENSIME mode"
@@ -430,5 +433,4 @@
 (provide 'ensime-mode)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime-model.el
+++ b/ensime-model.el
@@ -1,5 +1,9 @@
 ;;; ensime-model.el --- Data-structure accessors
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (defun ensime-search-sym-name (sym)
   (plist-get sym :name))
 
@@ -216,5 +220,4 @@
 (provide 'ensime-model)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime-notes.el
+++ b/ensime-notes.el
@@ -1,5 +1,9 @@
 ;;; ensime-notes.el --- Compiler Notes (Error/Warning overlays)
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 ;; Note: This might better be a connection-local variable, but
 ;; afraid that might lead to hanging overlays..
 
@@ -237,5 +241,4 @@ any buffer visiting the given file."
 (provide 'ensime-notes)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime-pkg.el
+++ b/ensime-pkg.el
@@ -2,15 +2,14 @@
   "ENhanced Scala Interaction Mode for Emacs"
   '((s "1.3.0")
     (dash "2.10.0")
-    (popup "0.5.0")
-    (auto-complete "1.4.0")
-    (scala-mode2 "0.21")
+    (auto-complete "1.5.0")
     (sbt-mode "0.03")
     (company "0.8.7")
     (yasnippet "0.8.0")
+    (popup "0.5.0")
+    (scala-mode2 "0.21")
     ))
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-popup.el
+++ b/ensime-popup.el
@@ -1,5 +1,9 @@
 ;;; ensime-popup.el --- popup buffer
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 ;;;;; Temporary popup buffers
 
 (defvar ensime-popup-buffer-map
@@ -34,6 +38,10 @@ See `view-return-to-alist' for a similar idea.")
 (make-variable-buffer-local
  (defvar ensime-is-popup-buffer nil
    "So we can query later whether this is a popup buffer."))
+
+(make-variable-buffer-local
+ (defvar ensime-popup-buffer-quit-function 'ensime-popup-buffer-quit
+   "The function that is used to quit a temporary popup buffer."))
 
 ;; Interface
 (defun ensime-make-popup-buffer (name buffer-vars &optional major-mode-fn)
@@ -98,24 +106,6 @@ The buffer also uses the minor-mode `ensime-popup-buffer-mode'."
 	(select-window selected-window)))
     ))
 
-
-(defmacro ensime-save-local-variables (vars &rest body)
-  (let ((vals (make-symbol "vals")))
-    `(let ((,vals (mapcar (lambda (var)
-			    (if (ensime-local-variable-p var)
-				(cons var (eval var))))
-			  ',vars)))
-       (prog1 (progn . ,body)
-	 (mapc (lambda (var+val)
-		 (when (consp var+val)
-		   (set (make-local-variable (car var+val)) (cdr var+val))))
-	       ,vals)))))
-
-
-(make-variable-buffer-local
- (defvar ensime-popup-buffer-quit-function 'ensime-popup-buffer-quit
-   "The function that is used to quit a temporary popup buffer."))
-
 (defun ensime-popup-buffer-quit-function (&optional kill-buffer-p)
   "Wrapper to invoke the value of `ensime-popup-buffer-quit-function'."
   (interactive)
@@ -136,5 +126,4 @@ The buffer also uses the minor-mode `ensime-popup-buffer-mode'."
 (provide 'ensime-popup)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime-refactor.el
+++ b/ensime-refactor.el
@@ -19,8 +19,9 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
-
-(eval-when-compile (require 'ensime-macros))
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
 
 (defvar ensime-refactor-id-counter 0
   "Each refactoring is given a unique id.")
@@ -209,6 +210,5 @@
 (provide 'ensime-refactor)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -38,7 +38,10 @@
 ;; - Removed global manipulations.
 ;; - Removed colorization attempts to use base sbt anis colorization.
 
-(eval-when-compile (require 'cl))
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (require 'sbt-mode)
 
 (defgroup ensime-sbt nil
@@ -109,6 +112,5 @@
 (provide 'ensime-sbt)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-scalex.el
+++ b/ensime-scalex.el
@@ -20,8 +20,11 @@
 ;;     MA 02111-1307, USA.
 
 (require 'json)
-(eval-when-compile (require 'cl))
 (require 'url)
+
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
 
 (defvar ensime-scalex-mode nil
   "Enables the ensime-scalex minor mode.")
@@ -460,6 +463,5 @@
 (provide 'ensime-scalex)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-search.el
+++ b/ensime-search.el
@@ -23,7 +23,6 @@
   (require 'cl)
   (require 'ensime-macros))
 
-
 (defvar ensime-search-mode nil
   "Enables the ensime-search minor mode.")
 
@@ -90,6 +89,9 @@
     (define-key map [(return)] 'ensime-search-choose-current-result)
     map)
   "Keymap used by ensime-search.")
+
+(defvar ensime-search-selection-overlay nil
+  "Overlay that highlights the currently selected search result.")
 
 
 (defstruct ensime-search-result
@@ -266,9 +268,6 @@
 
 
 
-(defvar ensime-search-selection-overlay nil
-  "Overlay that highlights the currently selected search result.")
-
 (defun ensime-search-update-result-selection ()
   "Move cursor to current result selection in target buffer."
   (when (and ensime-search-current-results
@@ -425,6 +424,5 @@
 
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -19,6 +19,9 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
 
 (defun ensime-sem-high-apply-properties (info)
   "Use provided info to modify font-lock properties of identifiers
@@ -133,6 +136,5 @@
 (provide 'ensime-semantic-highlight)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-stacktrace.el
+++ b/ensime-stacktrace.el
@@ -1,5 +1,9 @@
 ;;; ensime-stacktrace.el - Paste buffer for stack traces
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (defconst ensime-stacktrace-buffer-name-base "*ensime-stacktrace*")
 
 (defvar ensime-stacktrace-buffer-map
@@ -52,6 +56,5 @@ Create links to the source code."
 (provide 'ensime-stacktrace)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1383,34 +1383,12 @@
       (let* ((candidates (ensime--test-completions)))
         (ensime-assert (member "immutable" candidates)))
       (insert "utable.List")
-      (ensime-typecheck-current-file)
-      ))
 
-    ;; ((:full-typecheck-finished val)
-    ;;  (ensime-test-with-proj
-    ;;   (proj src-files)
-    ;;   ;; complete package member by class name
-    ;;   (ensime-test-eat-label "3")
-    ;;   (let* ((candidates (ensime--test-completions))
-    ;;          (to-inserts (mapcar (lambda (c) (get-text-property 0 'to-insert c))
-	;; 			candidates)))
-    ;;     (ensime-assert (member "scala.collection.immutable.Vector" to-inserts)))
-    ;;   (ensime-typecheck-current-file)
-    ;;   ))
-
-    ((:full-typecheck-finished val)
-     (ensime-test-with-proj
-      (proj src-files)
       ;; complete package member by class name in name list
       (ensime-test-eat-label "4")
       (let* ((candidates (ensime--test-completions)))
         (ensime-assert (member "Vector" candidates)))
-      (ensime-typecheck-current-file)
-      ))
 
-    ((:full-typecheck-finished val)
-     (ensime-test-with-proj
-      (proj src-files)
       ;; complete scala package in class body
       (ensime-test-eat-label "2")
       (let* ((candidates (ensime--test-completions)))
@@ -2108,5 +2086,4 @@ Must run the run-all script first to update the server."
 (provide 'ensime-test)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime-ui.el
+++ b/ensime-ui.el
@@ -19,7 +19,9 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
-
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
 
 ;; Event Handling
 
@@ -244,6 +246,5 @@
 (provide 'ensime-ui)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-undo.el
+++ b/ensime-undo.el
@@ -19,7 +19,9 @@
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 ;;     MA 02111-1307, USA.
 
-(eval-and-compile (require 'ensime-macros))
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
 
 (defvar ensime-undo-info-buffer-name "*ENSIME-Undo*")
 
@@ -91,6 +93,5 @@
 (provide 'ensime-undo)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -1,5 +1,9 @@
 ;;; ensime-var.el --- Customizaton variables
 
+(eval-when-compile
+  (require 'cl)
+  (require 'ensime-macros))
+
 (require 's)
 
 (defgroup ensime nil
@@ -224,5 +228,4 @@ name (case sensitive), and CONFIG-PLIST has the same format as
 (provide 'ensime-vars)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:

--- a/ensime.el
+++ b/ensime.el
@@ -33,10 +33,9 @@
   (when (<= emacs-major-version 21)
     (error "Ensime requires Emacs 22 or higher")))
 
-(eval-when-compile
+(eval-and-compile
   (require 'cl)
-  (require 'ensime-macros)
-  (require 'ensime-client))
+  (require 'ensime-macros))
 
 (require 'url-gw)
 (require 'dash)
@@ -51,6 +50,7 @@
 (require 'font-lock)
 (require 'auto-complete)
 (require 'easymenu)
+(require 'ensime-client)
 (require 'ensime-util)
 (require 'ensime-vars)
 (require 'ensime-config)
@@ -77,9 +77,6 @@
 (require 'ensime-semantic-highlight)
 (require 'ensime-ui)
 (require 'timer)
-(eval-when (compile)
-  (require 'apropos)
-  (require 'compile))
 
 (defvar ensime-protocol-version "0.7")
 
@@ -119,6 +116,5 @@
 (provide 'ensime)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; End:
 


### PR DESCRIPTION
This fixes ensime/ensime-server#310

- Move all macros to ensime-macros.el
- Fix dependency problems
- Fix some errors pointed out by byte compilation

I tested it with a local copy of melpa.  In the future we just need to keep all macros in ensime-macros.el file or we risk creating more errors.

At some point I'd like to fix every byte-compiler warnings: they're useful to detect typos and other problems. But there are so many spurious warnings right now that they mask the important ones.