### PR TITLE
Get classpath for repl from config rather than server, and remove dependency on scala binary

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -973,12 +973,6 @@ copies. All other objects are used unchanged. List must not contain cycles."
   (ensime-eval
    `(swank:symbol-at-point ,buffer-file-name ,(ensime-computed-point))))
 
-(defun ensime-rpc-repl-config ()
-  "Get the configuration information needed to launch the scala interpreter
-with the current project's dependencies loaded. Returns a property list."
-  (ensime-eval
-   `(swank:repl-config)))
-
 (defun ensime-rpc-remove-file (file-name)
   (ensime-eval `(swank:remove-file ,file-name)))
 

--- a/ensime-util.el
+++ b/ensime-util.el
@@ -211,6 +211,15 @@ Do not show 'Writing..' message."
        (rest paths))
     base))
 
+(defun ensime--build-classpath (paths)
+  "Build a classpath string from a list of paths"
+  (mapconcat #'identity paths ensime--classpath-separator))
+
+(defun ensime--scan-classpath (classpath pattern)
+  "Search through a classpath and extract paths that match the regexp specified"
+  (delq nil (mapcar (lambda (p) (and (string-match pattern p) p))
+                    (split-string classpath ensime--classpath-separator))))
+
 ;; Commonly used functions
 
 (defun ensime-curry (fun &rest args)
@@ -254,7 +263,10 @@ This idiom is preferred over `lexical-let'."
     (dolist (ea template)
       (cond
        ((keywordp ea)
-	(setq result (cons (plist-get proplist ea) result)))
+        (let ((val (plist-get proplist ea)))
+          (setq result (if (listp val)
+                           (append (reverse val) result)
+                         (cons val result)))))
        (t
 	(setq result (cons ea result)))))
     (reverse result)))


### PR DESCRIPTION
Two potential issues with this:

 * I don't fully understand the .ensime format so what I've done is a guess based on what ensime-sbt generates
 * The repl starts up with the following error:
Failed to created JLineReader: java.lang.NoClassDefFoundError: jline/console/completer/Completer
Falling back to SimpleReader.

jline is in SCALA_HOME/lib so I'm not sure how to locate it.  But then since completion doesn't work anyway perhaps this isn't a problem?
