### PR TITLE
defined stackframes can be folded

### DIFF
--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -305,12 +305,12 @@ the current project's dependencies. Returns list of form (cmd [arg]*)"
     (goto-char (point-at-bol 0)) ;; back up one line
     (when (search-forward-regexp "^[^ \t]" (point-at-eol) t)
       (put-text-property (point-at-bol) (point-at-eol)
-                         'font-lock-face 'compilation-error-face)))
+                         'font-lock-face 'compilation-warning)))
 
   (save-excursion
     (goto-char (point-at-bol))
     (put-text-property (point-at-bol) (point-at-eol)
-                       'font-lock-face 'compilation-error-face)
+                       'font-lock-face 'compilation-warning)
     (when
         (search-forward-regexp
          "^[ \t]+at \\([a-zA-Z0-9_$.]+\\)\\.\\([^.]+\\)(\\(.+\\):\\([0-9]+\\))[ \t]*$"
@@ -348,4 +348,3 @@ the current project's dependencies. Returns list of form (cmd [arg]*)"
 
 ;; Local Variables:
 ;; End:
-

--- a/ensime-pkg.el
+++ b/ensime-pkg.el
@@ -8,8 +8,8 @@
     (yasnippet "0.8.0")
     (popup "0.5.0")
     (scala-mode2 "0.21")
+    (fold-this "0.3.0")
     ))
 
 ;; Local Variables:
 ;; End:
-

--- a/ensime-stacktrace.el
+++ b/ensime-stacktrace.el
@@ -4,14 +4,25 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'fold-this)
+
 (defconst ensime-stacktrace-buffer-name-base "*ensime-stacktrace*")
 
 (defvar ensime-stacktrace-buffer-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") 'ensime-stacktrace-highlight)
+    (define-key map (kbd "C-c C-f") 'ensime-stacktrace-fold-buffer)
+    (define-key map (kbd "C-c C-p") 'fold-this-unfold-at-point)
     (define-key map (kbd "C-c C-q") 'quit-window)
     map)
   "Keymap for `ensime-stacktrace-buffer-mode'.")
+
+(defvar ensime-stacktrace-foldable-stackframes '("at akka\\.*"
+                                                 "at scala\\.*"
+                                                 "at java\\.*"
+                                                 "at jline\\.*"
+                                                 "at sbt\\.*"
+                                                 "at xsbt\\.*"))
 
 (define-minor-mode ensime-stacktrace-buffer-mode
   "Mode for highlighting stack traces"
@@ -40,6 +51,8 @@
          (when (= (buffer-size buf) 0)
            (insert ";; Stack trace buffer\n")
            (insert ";; Paste a stack trace below and press `C-c C-c' to create links to source code.\n")
+           (insert ";; Press `C-c C-f' to fold all defined stackframes\n")
+           (insert ";; Press `C-c C-p' to unfold region that you're currently on\n")
            (insert ";; Press `C-c C-q' to leave this buffer\n")
            (insert "\n"))
         (local-set-key (kbd "C-c C-c") 'ensime-stacktrace-highlight)
@@ -53,8 +66,49 @@ Create links to the source code."
   (set-text-properties (point-min) (point-max) nil)
   (ensime-inf-highlight-stack-traces (point-min) (point-max)))
 
+
+(defun ensime-stacktrace-pick-lines-to-fold (foldable-stackframes)
+  (save-excursion
+    (goto-char (point-min))
+    (goto-char (point-at-bol))
+    (let ((lines-to-fold '()))
+      (while
+          (search-forward-regexp
+           "^[ \t]+at .+(.+)[ \t]*$"
+           (point-max)
+           t)
+        (let ((stackframe (buffer-substring (point-at-bol) (point-at-eol))))
+          (when (--any (s-matches? it stackframe) foldable-stackframes)
+            (add-to-list 'lines-to-fold (line-number-at-pos)))))
+      lines-to-fold)))
+
+(defun ensime-stacktrace-group-lines-to-fold (lines)
+  (let (groups)
+    (dolist (line lines groups)
+      (let (current-group (car groups))
+        (if (-contains-p (car groups) (+ line 1))
+            (setq groups (append (list (append (list line) (car groups))) (cdr groups)))
+          (setq groups (append (list (list line)) groups)))))))
+
+(defun ensime-stacktrace-fold-lines (lines)
+  (save-excursion
+    (let ((first-line (car lines)))
+      (goto-line first-line)
+      (fold-this (point-at-bol) (point-at-eol (- (car (last lines)) (- first-line 1)))))))
+
+(defun ensime-stacktrace-fold-buffer ()
+  (interactive)
+  "Folds all stackframe lines in buffer that starts with
+package present in ENSIME-STACKFRAME-FOLDABLE-STACKFRAMES"
+  (fold-this-unfold-all)
+  (let* ((lines (ensime-stacktrace-pick-lines-to-fold ensime-stacktrace-foldable-stackframes))
+         (groups (ensime-stacktrace-group-lines-to-fold lines)))
+    (while groups
+      (print (car groups))
+      (ensime-stacktrace-fold-lines (car groups))
+      (setq groups (cdr groups)))))
+
 (provide 'ensime-stacktrace)
 
 ;; Local Variables:
 ;; End:
-

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -912,7 +912,27 @@
                                    :classpath ,(ensime--build-classpath
                                                 '("/x/y/scala-compiler-2.11.5.jar" "/x/y/scala-reflect-2.11.5.jar"
                                                   "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m")))))
-        (delete-file (ensime--classpath-file "test-inf-repl-config")))))))
+        (delete-file (ensime--classpath-file "test-inf-repl-config")))))
+   (ensime-test
+    "Test ensime-stacktrace-pick-lines-to-fold"
+    (with-temp-buffer
+      (insert (concat "java.util.NoSuchElementException: None.get\n"
+	"\tat scala.None$.get(Option.scala:347)\n"
+	"\tat scala.None$.get(Option.scala:345)\n"
+	"\tat akka.actor.ActorCell.invoke(ActorCell.scala:487)\n"
+	"\tat akka.dispatch.Mailbox.processMailbox(Mailbox.scala:254)\n"
+	"\tat akka.dispatch.Mailbox.run(Mailbox.scala:221)\n"
+	"\tat akka.dispatch.Mailbox.exec(Mailbox.scala:231)\n"
+	"\tat scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)\n"
+	"\tat scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.pollAndExecAll(ForkJoinPool.java:1253)\n"
+	"\tat scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1346)\n"
+	"\tat scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)\n"))
+      (let ((lines-to-fold (ensime-stacktrace-pick-lines-to-fold '("at akka\\.*"))))
+        (ensime-assert-equal '(7 6 5 4) lines-to-fold))))
+   (ensime-test
+    "Test ensime-stacktrace-groups-lines-to-fold"
+    (let ((grouped-lines (ensime-stacktrace-group-lines-to-fold '(10 9 8 6 5 3 1))))
+      (ensime-assert-equal '((1) (3) (5 6) (8 9 10)) grouped-lines)))))
 
 (defun ensime--test-completions ()
   "Helper for completion testing."


### PR DESCRIPTION
I tested it after pasting stacktrace to buffer that was created by `ensime-stacktrace-switch`. I realize that it's not finished but I would rather like to get some hints about what should I change after someone have a chance to look at code.

This should fix https://github.com/ensime/ensime-server/issues/566 eventually