### PR TITLE
Allows to configure the user's ensime directory

### DIFF
--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -19,6 +19,10 @@
 
 (defvar ensime--abort-connection nil)
 
+(defvar user-emacs-ensime-directory "ensime"
+  "The directory to store the calculated classpaths for the ensime server
+  when running `ensime-update' or starting a server for the first time.")
+
 (defconst ensime--sbt-start-template
 "
 import sbt._
@@ -179,7 +183,7 @@ Analyzer will be restarted."
 
 (defun ensime--user-directory ()
   (file-name-as-directory
-   (expand-file-name "ensime" user-emacs-directory)))
+   (expand-file-name user-emacs-ensime-directory user-emacs-directory)))
 
 (defun ensime--classpath-file (scala-version)
   (expand-file-name


### PR DESCRIPTION
It might be useful in some cases to be able to configure (or to change) the path to the users ensime directory. E.g. if ".emacs.d" directory is a emacs kit project cloned from github. So, the change will allow to configure the path `(setq user-emacs-ensime-directory ".cache/ensime")` without updating .gitignore.