### PR TITLE
ensime--retry-connect: after successful connection, don't try to dele…

### DIFF
--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -347,7 +347,11 @@ defined."
 		 ;; visible.
 		 (when-let
 		  (win (get-buffer-window (process-buffer server-proc)))
-		  (delete-window win)))
+                  (cond
+                   ((window-parent)
+                    (delete-window win))
+                   (t
+                    (switch-to-prev-buffer nil t)))))
 	     (run-at-time
 	      "6 sec" nil 'ensime-timer-call 'ensime--retry-connect
 	      server-proc host port-fn config cache-dir))))))


### PR DESCRIPTION
ensime--retry-connect: after successful connection, don't try to delete the current window if it's the only window, as doing this creates an error which breaks ensime.

Instead, switch the view back to the previous buffer, which is usually the buffer from which 'M-x ensime' was invoked.
