### PR TITLE
Use hideshow instead of fold-this for foldable stack frames.

### DIFF
--- a/ensime-pkg.el
+++ b/ensime-pkg.el
@@ -8,7 +8,6 @@
     (yasnippet "0.8.0")
     (popup "0.5.0")
     (scala-mode2 "0.21")
-    (fold-this "0.3.0")
     ))
 
 ;; Local Variables:


### PR DESCRIPTION
Hideshow is included with emacs but fold-this isn't, so using hideshow makes it easier to install 