### PR TITLE
Implicit conversion highlighting

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -879,7 +879,7 @@ copies. All other objects are used unchanged. List must not contain cycles."
 
 (defun ensime-rpc-doc-uri-at-point (file point)
   (ensime-eval
-   `(swank:doc-uri-at-point ,file ,point)))
+   `(swank:doc-uri-at-point ,file ,(ensime-externalize-offset point))))
 
 (defun ensime-rpc-doc-uri-for-symbol (fqn &optional member-name member-signature)
   (ensime-eval

--- a/ensime-client.el
+++ b/ensime-client.el
@@ -1115,8 +1115,17 @@ copies. All other objects are used unchanged. List must not contain cycles."
   (ensime-eval `(swank:shutdown-server)))
 
 (defun ensime-rpc-symbol-designations (file start end requested-types continue)
+  (when (version< (ensime-protocol-version) "0.8.15")
+    (setq requested-types (remove 'implicitParams requested-types))
+    (setq requested-types (remove 'implicitConversion requested-types)))
   (ensime-eval-async `(swank:symbol-designations ,file ,start ,end ,requested-types)
 		     continue))
+
+(defun ensime-rpc-implicit-info-in-range (start end)
+  (when (version<= "0.8.15" (ensime-protocol-version))
+    (ensime-eval `(swank:implicit-info
+                   ,(buffer-file-name)
+                   (,(ensime-externalize-offset start) ,(ensime-externalize-offset end))))))
 
 (defun ensime-rpc-get-call-completion (id)
   (if (and (integerp id) (> id -1))

--- a/ensime-client.el
+++ b/ensime-client.el
@@ -1115,14 +1115,14 @@ copies. All other objects are used unchanged. List must not contain cycles."
   (ensime-eval `(swank:shutdown-server)))
 
 (defun ensime-rpc-symbol-designations (file start end requested-types continue)
-  (when (version< (ensime-protocol-version) "0.8.15")
+  (when (version< (ensime-protocol-version) "0.8.16")
     (setq requested-types (remove 'implicitParams requested-types))
     (setq requested-types (remove 'implicitConversion requested-types)))
   (ensime-eval-async `(swank:symbol-designations ,file ,start ,end ,requested-types)
 		     continue))
 
 (defun ensime-rpc-implicit-info-in-range (start end)
-  (when (version<= "0.8.15" (ensime-protocol-version))
+  (when (version<= "0.8.16" (ensime-protocol-version))
     (ensime-eval `(swank:implicit-info
                    ,(buffer-file-name)
                    (,(ensime-externalize-offset start) ,(ensime-externalize-offset end))))))

--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -26,6 +26,11 @@
   "Face used for marking the line on which an error occurs."
   :group 'ensime-ui)
 
+(defface ensime-compile-infoline
+  '((t (:inherit compilation-info)))
+  "Face used for marking a line on which there is information available."
+  :group 'ensime-ui)
+
 (defvar ensime-selection-overlay nil)
 
 (defvar ensime-selection-stack nil)

--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -35,7 +35,16 @@
 		 (start (nth 1 sym))
 		 (end (nth 2 sym))
 		 (face (cdr (assoc type ensime-sem-high-faces))))
+            (when (eq type 'implicitParams)
+              (setq start end)
+              (setq end (1+ end)))
 	    (let ((ov (make-overlay start end buf)))
+              (when (or (eq type 'implicitParams)
+                        (eq type 'implicitConversion))
+                (overlay-put ov 'before-string
+                             (propertize "."
+                                         'display
+                                         '(left-fringe question-mark ensime-compile-warnline))))
 	      (overlay-put ov 'face face)
 	      (overlay-put ov 'ensime-sem-high-overlay t)
 	      (overlay-put ov 'ensime-sym-type type))))))))
@@ -124,9 +133,9 @@
 			     (overlay-get ov 'ensime-sym-type)))
 		   ovs))))
 
-(defun ensime-sem-high-sym-types-at-point ()
+(defun ensime-sem-high-sym-types-at-point (&optional point)
   (interactive)
-  (let ((ovs (overlays-at (point))))
+  (let ((ovs (overlays-at (or point (point)))))
     (mapcar
      (lambda (ov)
        (overlay-get ov 'ensime-sym-type))

--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -44,7 +44,7 @@
                 (overlay-put ov 'before-string
                              (propertize "."
                                          'display
-                                         '(left-fringe question-mark ensime-compile-warnline))))
+                                         '(left-fringe breakpoint ensime-compile-infoline))))
 	      (overlay-put ov 'face face)
 	      (overlay-put ov 'ensime-sem-high-overlay t)
 	      (overlay-put ov 'ensime-sym-type type))))))))

--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -384,7 +384,8 @@ defined."
    ((version<= (ensime-protocol-version conn) "0.8.9")
     (ensime-eval-async `(swank:init-project (:name "NA")) 'identity))
 
-   (t (ensime-eval-async `(swank:init-project) 'identity))))
+   ((version<= (ensime-protocol-version conn) "0.8.14")
+    (ensime-eval-async `(swank:init-project) 'identity))))
 
 
 (provide 'ensime-startup)

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -905,7 +905,11 @@
       (unwind-protect
           (progn
             (ensime-write-to-file (ensime--classpath-file "test-inf-repl-config")
-                                  "/x/y/scala-compiler-2.11.5.jar:/x/y/something-else-1.2.jar:/x/y/scala-reflect-2.11.5.jar")
+                                  (mapconcat #'identity
+                                             '("/x/y/scala-compiler-2.11.5.jar"
+                                               "/x/y/something-else-1.2.jar"
+                                               "/x/y/scala-reflect-2.11.5.jar")
+                                             ensime--classpath-separator))
             (ensime-assert-equal (ensime-inf-repl-config test-config)
                                  `(:java "/x/y/jdk/bin/java"
                                    :java-flags ("flag1" "flag2")
@@ -1825,21 +1829,26 @@
                                  "package pack"
                                  "import java.io.File"
                                  "class A(value:String) extends /*9*/Object{"
-                                 "case class Dude(name:Integer)"
-                                 "val myTick/*7*/ = 0"
-                                 "var myTock/*8*/ = 0"
-                                 "def hello(){"
-                                 "  var tick/*2*/ = 1"
-                                 "  val tock/*6*/ = 2"
-                                 "  /*5*/println(new /*1*/File(\".\"))"
-                                 "  /*3*/tick = /*4*/tick + 1"
-                                 "  val d = /*10*/Dude(1)"
-                                 "  d match{"
-                                 "    case /*11*/Dude(i) => {}"
-                                 "    case o:/*12*/Object => {}"
-                                 "    case _ => {}"
+                                 "  case class Dude(name:Integer)"
+                                 "  val myTick/*7*/ = 0"
+                                 "  var myTock/*8*/ = 0"
+                                 "  def hello(){"
+                                 "    var tick/*2*/ = 1"
+                                 "    val tock/*6*/ = 2"
+                                 "    /*5*/println(new /*1*/File(\".\"))"
+                                 "    /*3*/tick = /*4*/tick + 1"
+                                 "    val d = /*10*/Dude(1)"
+                                 "    d match{"
+                                 "      case /*11*/Dude(i) => {}"
+                                 "      case o:/*12*/Object => {}"
+                                 "      case _ => {}"
+                                 "    }"
                                  "  }"
                                  "}"
+                                 "class B {}"
+                                 "class C{"
+                                 " implicit def stringToB(s: String) = new B"
+                                 " val x: B = \"xxx\"/*13*/"
                                  "}"))))))
       (ensime-test-init-proj proj))
 
@@ -1885,7 +1894,37 @@
         (funcall check-sym-is 'object)
 
         (goto-char (ensime-test-after-label "12"))
-        (funcall check-sym-is 'class))
+        (funcall check-sym-is 'class)
+
+        (goto-char (ensime-test-before-label "13"))
+        (funcall check-sym-is 'implicitConversion))
+
+       (ensime-test-cleanup proj))))
+
+   (ensime-async-test
+    "Test implicit notes."
+    (let* ((proj (ensime-create-tmp-project
+                  `((:name
+                     "pack/a.scala"
+                     :contents ,(ensime-test-concat-lines
+                                 "package pack"
+                                 "class B {}"
+                                 "class C{"
+                                 " implicit def stringToB(s: String)(implicit x: Int) = new B"
+                                 " implicit val zz: Int = 1"
+                                 " val xx: B = \"xxx\"/*1*/"
+                                 "}"))))))
+      (ensime-test-init-proj proj))
+
+    ((:connected :compiler-ready :full-typecheck-finished)
+     (ensime-test-with-proj
+      (proj src-files)
+
+      (goto-char (ensime-test-before-label "1"))
+      (ensime-assert-equal
+       (ensime-implicit-notes-at (point))
+       '("Implicit parameters added to call of stringToB(\"xxx\"): (zz)"
+         "Implicit conversion of \"xxx\" using stringToB"))
 
       (ensime-test-cleanup proj))))
 

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1923,11 +1923,10 @@
       (goto-char (ensime-test-before-label "1"))
       (ensime-assert-equal
        (ensime-implicit-notes-at (point))
-       '("Implicit parameters added to call of stringToB(\"xxx\"): (zz)"
-         "Implicit conversion of \"xxx\" using stringToB"))
+       '("Implicit parameters added to call of stringToB(\"xxx\"): (zz: scala.Int)"
+         "Implicit conversion of \"xxx\" using stringToB: (s: String)(implicit x: Int)pack.B"))
 
       (ensime-test-cleanup proj))))
-
    (ensime-async-test
     "Test debugging scala project."
     (let* ((proj (ensime-create-tmp-project

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -140,7 +140,9 @@ is saved."
     (class . font-lock-type-face)
     (trait .  (:inherit font-lock-type-face :slant italic))
     (object . font-lock-constant-face)
-    (package . font-lock-preprocessor-face))
+    (package . font-lock-preprocessor-face)
+    (implicitConversion . ensime-warnline-highlight)
+    (implicitParams . ensime-warnline-highlight))
   "Faces for semantic highlighting. Symbol types not mentioned here
 will not be requested from server.  The format is an alist of the form
   ( SYMBOL-TYPE . FACE-SPEC )

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -141,8 +141,8 @@ is saved."
     (trait .  (:inherit font-lock-type-face :slant italic))
     (object . font-lock-constant-face)
     (package . font-lock-preprocessor-face)
-    (implicitConversion . ensime-warnline-highlight)
-    (implicitParams . ensime-warnline-highlight))
+    (implicitConversion . ensime-implicit-highlight)
+    (implicitParams . ensime-implicit-highlight))
   "Faces for semantic highlighting. Symbol types not mentioned here
 will not be requested from server.  The format is an alist of the form
   ( SYMBOL-TYPE . FACE-SPEC )


### PR DESCRIPTION
This PR goes with ensime/ensime-server#1004 . I could use some feedback on the UI.

- Implicit conversions are shown using the compiler-warning face, and with a question mark in the margin
- For implicit parameters, only the last character is highlighted. The reason is that the conversion ranges are usually pretty large (think

```
something map {
...
}
```

so I didn't want to highlight the whole thing

- hovering on a highlighted area, or typing `C-c C-v e`  (same keybinding as for showing compiler notes) anywhere on a line shows all implicits that are applied on that line.

Future work should include jumping to the definition of the implicit(s) being applied.
