### PR TITLE
Require config file but not server to launch a REPL.

### DIFF
--- a/ensime-config.el
+++ b/ensime-config.el
@@ -80,8 +80,8 @@
 		  guess
 		  nil
 		  (if guess (file-name-nondirectory guess) "")))))
-
-    (if (and (file-exists-p file)
+    (if (and file
+             (file-exists-p file)
              (not (file-directory-p file)))
         file
       (warn (concat

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -2002,6 +2002,20 @@
      (ensime-test-with-proj
       (proj src-files)
       (ensime-test-cleanup proj))))
+
+   (ensime-test
+    "REPL without server."
+    (let ((proj (ensime-create-tmp-project '((:name "test.scala" :contents "")))))
+      (unwind-protect
+          (progn
+            (find-file (car (plist-get proj :src-files)))
+            (let* ((ensime-prefer-noninteractive t)
+                   (proc (ensime-inf-run-scala)))
+              (ensime-inf-quit-interpreter)
+              (while (process-live-p proc) (accept-process-output proc))
+              (ensime-assert-equal (process-status proc) 'exit)
+              (ensime-assert-equal (process-exit-status proc) 0)))
+        (ensime-cleanup-tmp-project proj))))
   ))
 
 


### PR DESCRIPTION
As suggested here: https://github.com/ensime/ensime-server/issues/972#issuecomment-104881777

Implementing this now because it will make it easier to write tests for https://github.com/ensime/ensime-emacs/pull/143
