### PR TITLE
Ensure that cursors are non-negative

### DIFF
--- a/ensime-inspector.el
+++ b/ensime-inspector.el
@@ -475,6 +475,8 @@ inspect the package of the current source file."
   (setq ensime-inspector-history-cursor
 	(min (- (length ensime-inspector-history) 1)
 	     (+ ensime-inspector-history-cursor 1)))
+  (setq ensime-inspector-history-cursor
+        (max 0 ensime-inspector-history-cursor))
   (ensime-inspector-goto-cursor))
 
 (defun ensime-inspector-forward-page ()

--- a/ensime-macros.el
+++ b/ensime-macros.el
@@ -99,10 +99,10 @@ If PROCESS is not specified, `ensime-connection' is used.
 
       ;; Clamp the history cursor
       (setq ensime-inspector-history-cursor
-	    (max 0 ensime-inspector-history-cursor))
-      (setq ensime-inspector-history-cursor
 	    (min (- (length ensime-inspector-history) 1)
 		 ensime-inspector-history-cursor))
+      (setq ensime-inspector-history-cursor
+	    (max 0 ensime-inspector-history-cursor))
 
       ;; Remove all elements preceding the cursor (the 'redo' history)
       (setq ensime-inspector-history

--- a/ensime-ui.el
+++ b/ensime-ui.el
@@ -90,6 +90,8 @@
   (setq ensime-ui-nav-history-cursor
 	(min (- (length ensime-ui-nav-history) 1)
 	     (+ ensime-ui-nav-history-cursor 1)))
+  (setq ensime-ui-nav-history-cursor
+        (max 0 ensime-ui-nav-history-cursor))
   (ensime-ui-nav-goto-cursor))
 
 (defun ensime-ui-nav-forward-page ()
@@ -156,10 +158,10 @@
 	(when (not ensime-ui-nav-paging-in-progress)
 	  ;; Clamp the history cursor
 	  (setq ensime-ui-nav-history-cursor
-		(max 0 ensime-ui-nav-history-cursor))
-	  (setq ensime-ui-nav-history-cursor
 		(min (- (length ensime-ui-nav-history) 1)
 		     ensime-ui-nav-history-cursor))
+	  (setq ensime-ui-nav-history-cursor
+		(max 0 ensime-ui-nav-history-cursor))
 	  ;; Remove all elements preceding the cursor (the 'redo' history)
 	  (setq ensime-ui-nav-history
 		(subseq ensime-ui-nav-history


### PR DESCRIPTION
Emacs 25 will throw a bad bounding indices error if subseq is called on
an empty list with a negative index.

This fixes #233 