### PR TITLE
Replace custom when-let with dash -when-let

### DIFF
--- a/ensime-config.el
+++ b/ensime-config.el
@@ -74,8 +74,8 @@ NO-REF-SOURCES allows skipping the extracted dependencies."
 	    'file-directory-p
 	    (append (ensime-config-source-roots conf)
 		    (unless no-ref-sources
-		      (when-let (dir (ensime-source-jars-dir conf))
-				(list dir)))))))
+		      (-when-let (dir (ensime-source-jars-dir conf))
+                        (list dir)))))))
       (-first (lambda (dir) (ensime-path-includes-dir-p file dir))
 	      source-roots))))
 
@@ -154,7 +154,7 @@ only sbt projects are supported."
 
 (defun ensime--maybe-refresh-config (force after-refresh-fn no-refresh-fn)
   (let ((no-refresh-reason "couldn't detect project type"))
-    (when-let (project-root (sbt:find-root))
+    (-when-let (project-root (sbt:find-root))
       (let ((config-file (ensime--join-paths project-root ".ensime")))
         (if (or force
                 (ensime--config-sbt-needs-refresh-p project-root config-file))
@@ -185,8 +185,8 @@ only sbt projects are supported."
 (defun ensime--refresh-config-sentinel (process event on-success-fn)
   (cond
    ((equal event "finished\n")
-    (when-let (win (get-buffer-window (process-buffer process)))
-              (delete-window win))
+    (-when-let (win (get-buffer-window (process-buffer process)))
+      (delete-window win))
     (funcall on-success-fn))
    (t
     (message "Process %s exited: %s" process event))))

--- a/ensime-debug.el
+++ b/ensime-debug.el
@@ -23,6 +23,7 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'dash)
 (require 'gdb-mi)
 
 (defgroup ensime-db nil
@@ -179,12 +180,12 @@
      (plist-get evt :file)
      (plist-get evt :line)))
 
-  (when-let (exc-val (ensime-rpc-debug-value
-                      (ensime-db-make-obj-ref-location
-                       (plist-get evt :exception))))
-            (ensime-ui-show-nav-buffer
-             ensime-db-value-buffer
-             exc-val t))
+  (-when-let (exc-val (ensime-rpc-debug-value
+                       (ensime-db-make-obj-ref-location
+                        (plist-get evt :exception))))
+    (ensime-ui-show-nav-buffer
+     ensime-db-value-buffer
+     exc-val t))
   ;;  (run-hooks 'ensime-db-thread-suspended-hook)
   )
 
@@ -240,14 +241,14 @@
 (defun ensime-db-set-debug-marker (file line)
   "Open location in a new window."
   (ensime-db-clear-marker-overlays)
-  (when-let (ov (ensime-make-overlay-at
-                 file line nil nil
-                 "Debug Marker"
-                 (list :face 'ensime-marker-face
-                       :char ">"
-                       :bitmap 'right-triangle
-                       :fringe 'ensime-compile-errline)))
-            (push ov ensime-db-marker-overlays))
+  (-when-let (ov (ensime-make-overlay-at
+                  file line nil nil
+                  "Debug Marker"
+                  (list :face 'ensime-marker-face
+                        :char ">"
+                        :bitmap 'right-triangle
+                        :fringe 'ensime-compile-errline)))
+    (push ov ensime-db-marker-overlays))
 
   (ensime-goto-source-location
    (list :file file :line line)
@@ -259,11 +260,11 @@
     (let ((file (ensime-pos-file pos))
           (line (ensime-pos-line pos)))
       (when (and (stringp file) (integerp line))
-        (when-let (ov (ensime-make-overlay-at
-                       file line nil nil
-                       "Breakpoint"
-                       visuals))
-                  (push ov ensime-db-breakpoint-overlays))))))
+        (-when-let (ov (ensime-make-overlay-at
+                        file line nil nil
+                        "Breakpoint"
+                        visuals))
+          (push ov ensime-db-breakpoint-overlays))))))
 
 
 (defun ensime-db-refresh-breakpoints ()
@@ -571,17 +572,17 @@
                                   visitor)
   (let ((field-name (plist-get field :name)))
     (funcall (plist-get visitor :object-field) val field path)
-    (when-let (sub-expansion (ensime-db-sub-expansion
-                              expansion field-name))
-              (let ((sub-val (ensime-rpc-debug-value
-                              (ensime-db-make-obj-field-location
-                               (plist-get val :object-id)
-                               field-name)
-                              )))
-                (ensime-db-visit-value sub-val sub-expansion
-                                       (append path (list field-name))
-                                       visitor)
-                ))))
+    (-when-let (sub-expansion (ensime-db-sub-expansion
+                               expansion field-name))
+      (let ((sub-val (ensime-rpc-debug-value
+                      (ensime-db-make-obj-field-location
+                       (plist-get val :object-id)
+                       field-name)
+                      )))
+        (ensime-db-visit-value sub-val sub-expansion
+                               (append path (list field-name))
+                               visitor)
+        ))))
 
 
 
@@ -591,15 +592,15 @@
                                  path
                                  visitor)
   (funcall (plist-get visitor :array-el) val i path)
-  (when-let (sub-expansion (ensime-db-sub-expansion
-                            expansion i))
-            (let ((sub-val (ensime-rpc-debug-value
-                            (ensime-db-make-array-el-location
-                             (plist-get val :object-id)
-                             i))))
-              (ensime-db-visit-value sub-val sub-expansion
-                                     (append path (list i))
-                                     visitor))))
+  (-when-let (sub-expansion (ensime-db-sub-expansion
+                             expansion i))
+    (let ((sub-val (ensime-rpc-debug-value
+                    (ensime-db-make-array-el-location
+                     (plist-get val :object-id)
+                     i))))
+      (ensime-db-visit-value sub-val sub-expansion
+                             (append path (list i))
+                             visitor))))
 
 
 
@@ -610,13 +611,13 @@
 
   (case (plist-get val :val-type)
 
-    (ref (when-let (looked-up (ensime-rpc-debug-value
-                               (ensime-db-make-obj-ref-location
-                                (plist-get val :object-id))))
-                   (ensime-db-visit-value looked-up
-                                          expansion
-                                          path
-                                          visitor)))
+    (ref (-when-let (looked-up (ensime-rpc-debug-value
+                                (ensime-db-make-obj-ref-location
+                                 (plist-get val :object-id))))
+           (ensime-db-visit-value looked-up
+                                  expansion
+                                  path
+                                  visitor)))
 
     (prim (funcall (plist-get visitor :primitive) val path))
 

--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -4,6 +4,8 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'dash)
+
 (defvar ensime-compile-result-buffer-name "*ENSIME-Compilation-Result*")
 
 (defvar ensime-compile-result-map
@@ -611,18 +613,18 @@ currently open in emacs."
 			   ((listp f) (car f))))
 	       (src (cond ((stringp f) f)
 			  ((listp f) (cadr f)))))
-	  (when-let (buf (find-buffer-visiting dest))
-                    (with-current-buffer buf
-		      (insert-file-contents src nil nil nil t)
-		      ;; Rather than pass t to 'visit' the file by way of
-		      ;; insert-file-contents, we manually clear the
-		      ;; modification flags. This way the buffer-file-name
-		      ;; is untouched.
-		      (when (equal dest src)
-			(clear-visited-file-modtime)
-			(set-buffer-modified-p nil))
-                      (when typecheck
-                        (ensime-typecheck-current-file)))))))
+	  (-when-let (buf (find-buffer-visiting dest))
+            (with-current-buffer buf
+              (insert-file-contents src nil nil nil t)
+              ;; Rather than pass t to 'visit' the file by way of
+              ;; insert-file-contents, we manually clear the
+              ;; modification flags. This way the buffer-file-name
+              ;; is untouched.
+              (when (equal dest src)
+                (clear-visited-file-modtime)
+                (set-buffer-modified-p nil))
+              (when typecheck
+                (ensime-typecheck-current-file)))))))
     (goto-char pt)))
 
 ;; Expand selection

--- a/ensime-inspector.el
+++ b/ensime-inspector.el
@@ -4,6 +4,8 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'dash)
+
 ;; Type Inspector UI
 
 (defvar ensime-inspector-buffer-name "*Inspector*")
@@ -285,11 +287,11 @@
 	   (insert "\n")
 
 	   ;; Insert a link to the companion object or class, if extant
-	   (when-let (id companion-id)
-                     (ensime-inspector-insert-link-to-type
-                      "(companion)" id
-                      (ensime-companion-type-name full-type-name)
-                      (not (ensime-type-is-object-p type))))
+	   (-when-let (id companion-id)
+             (ensime-inspector-insert-link-to-type
+              "(companion)" id
+              (ensime-companion-type-name full-type-name)
+              (not (ensime-type-is-object-p type))))
 
 	   ;; Display each member, arranged by owner type
 	   (dolist (interface interfaces)
@@ -404,19 +406,19 @@ read a fully qualified path from the minibuffer."
 
 (defun ensime-imported-type-path-at-point ()
   "Return the qualified name of the type being imported at point."
-  (when-let (sym (symbol-at-point))
-            (let ((sym-name (ensime-kill-txt-props
-                             (symbol-name sym))))
-              (when (and (integerp (string-match "^[A-ZA-z_]+$" sym-name))
-                         (save-excursion
-                           (beginning-of-line)
-                           (search-forward-regexp
-                            (concat
-                             "^\\s-*import \\(\\(?:[a-z0-9_]+\\.\\)*\\)"
-                             "\\(?:[A-Z][A-z0-9_\\.]+\\|{[A-z0-9_\\., \n]+}\\)$")
-                            (point-at-eol) t)))
-                (let ((path (ensime-kill-txt-props (match-string 1))))
-                  (concat path sym-name))))))
+  (-when-let (sym (symbol-at-point))
+    (let ((sym-name (ensime-kill-txt-props
+                     (symbol-name sym))))
+      (when (and (integerp (string-match "^[A-ZA-z_]+$" sym-name))
+                 (save-excursion
+                   (beginning-of-line)
+                   (search-forward-regexp
+                    (concat
+                     "^\\s-*import \\(\\(?:[a-z0-9_]+\\.\\)*\\)"
+                     "\\(?:[A-Z][A-z0-9_\\.]+\\|{[A-z0-9_\\., \n]+}\\)$")
+                    (point-at-eol) t)))
+        (let ((path (ensime-kill-txt-props (match-string 1))))
+          (concat path sym-name))))))
 
 (defun ensime-inspect-package-at-point ()
   "If cursor is over a package path, inspect that path. Otherwise,

--- a/ensime-macros.el
+++ b/ensime-macros.el
@@ -33,13 +33,6 @@ If not, message the user."
        (message
 	"This command requires a connection to an ENSIME server."))))
 
-(defmacro* when-let ((var value) &rest body)
-  "Evaluate VALUE, if the result is non-nil bind it to VAR and eval BODY.
-
-\(fn (VAR VALUE) &rest BODY)"
-  `(let ((,var ,value))
-     (when ,var ,@body)))
-
 (defmacro* ensime-with-popup-buffer ((name &optional connection select major-mode-fn)
 				     &body body)
   "Similar to `with-output-to-temp-buffer'.

--- a/ensime-notes.el
+++ b/ensime-notes.el
@@ -4,6 +4,7 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'dash)
 (require 'cl-lib)
 
 ;; Note: This might better be a connection-local variable, but
@@ -55,19 +56,19 @@ any buffer visiting the given file."
         (end e))
     (assert (or (integerp line)
                 (and (integerp beg) (integerp end))))
-    (when-let (buf (find-buffer-visiting file))
-              (with-current-buffer buf
-                (if (and (integerp beg) (integerp end))
-                    (progn
-                      (setq beg (ensime-internalize-offset beg))
-                      (setq end (ensime-internalize-offset end)))
-                  ;; If line provided, use line to define region
-                  (save-excursion
-                    (goto-line line)
-                    (setq beg (point-at-bol))
-                    (setq end (point-at-eol)))))
+    (-when-let (buf (find-buffer-visiting file))
+      (with-current-buffer buf
+        (if (and (integerp beg) (integerp end))
+            (progn
+              (setq beg (ensime-internalize-offset beg))
+              (setq end (ensime-internalize-offset end)))
+          ;; If line provided, use line to define region
+          (save-excursion
+            (goto-line line)
+            (setq beg (point-at-bol))
+            (setq end (point-at-eol)))))
 
-              (ensime-make-overlay beg end msg visuals nil buf))
+      (ensime-make-overlay beg end msg visuals nil buf))
     ))
 
 
@@ -98,9 +99,9 @@ any buffer visiting the given file."
 		     :bitmap 'question-mark
 		     :fringe 'ensime-compile-warnline)))))
 
-        (when-let (ov (ensime-make-overlay-at file line beg end msg visuals))
-                  (overlay-put ov 'lang lang)
-                  (push ov ensime-note-overlays))
+        (-when-let (ov (ensime-make-overlay-at file line beg end msg visuals))
+          (overlay-put ov 'lang lang)
+          (push ov ensime-note-overlays))
 
         ))))
 

--- a/ensime-search.el
+++ b/ensime-search.el
@@ -23,6 +23,8 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'dash)
+
 (defvar ensime-search-mode nil
   "Enables the ensime-search minor mode.")
 
@@ -353,8 +355,8 @@
      (lambda (item)
        (make-ensime-search-result
 	:summary (ensime-search-sym-name item)
-	:match-file-name (when-let (pos (ensime-search-sym-pos item))
-                                   (ensime-pos-file pos))
+	:match-file-name (-when-let (pos (ensime-search-sym-pos item))
+                           (ensime-pos-file pos))
 	:data item))
      items)))
 
@@ -391,7 +393,7 @@
 	(ensime-search-highlight-matches text p))
 
       ;; Insert filename
-      (when-let (f (ensime-search-result-match-file-name r))
+      (-when-let (f (ensime-search-result-match-file-name r))
 	(ensime-insert-with-face (format " %s" f)
 				 'font-lock-comment-face))
 

--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -23,12 +23,14 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'dash)
+
 (defun ensime-sem-high-apply-properties (info)
   "Use provided info to modify font-lock properties of identifiers
  in the program text."
   (let ((file (plist-get info :file))
 	(syms (plist-get info :syms)))
-    (when-let (buf (find-buffer-visiting file))
+    (-when-let (buf (find-buffer-visiting file))
       (with-current-buffer buf
 	(dolist (sym (ensime-sem-high-internalize-syms syms))
 	  (let* ((type (nth 0 sym))

--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -4,6 +4,8 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'dash)
+
 (defvar ensime-idle-typecheck-timer nil
   "Timer called when emacs is idle")
 
@@ -191,9 +193,9 @@ Analyzer will be restarted."
     (let ((classpath-file (ensime--classpath-file scala-version)))
       (if (file-exists-p classpath-file)
           (progn
-            (when-let
-             (win (get-buffer-window (process-buffer process)))
-             (delete-window win))
+            (-when-let
+                (win (get-buffer-window (process-buffer process)))
+              (delete-window win))
             (funcall on-success-fn))
         (message "Could not create classpath file %s" classpath-file))))
    (t
@@ -328,13 +330,13 @@ defined."
 		 (ensime--connect host port config)
 		 ;; Kill the window displaying the server buffer if it's still
 		 ;; visible.
-		 (when-let
-		  (win (get-buffer-window (process-buffer server-proc)))
-                  (cond
-                   ((window-parent)
-                    (delete-window win))
-                   (t
-                    (switch-to-prev-buffer nil t)))))
+		 (-when-let
+                     (win (get-buffer-window (process-buffer server-proc)))
+                   (cond
+                    ((window-parent)
+                     (delete-window win))
+                    (t
+                     (switch-to-prev-buffer nil t)))))
 	     (run-at-time
 	      "6 sec" nil 'ensime-timer-call 'ensime--retry-connect
 	      server-proc host port-fn config cache-dir))))))


### PR DESCRIPTION
The custom `when-let` from `ensime-macros.el` macro is incompatible with `when-let` from `subr-x.el` introduced in Emacs 25, which can cause subtle breakage if a caller expects to get the `subr-x` variant, but ends up with the one from Ensime or vice versa.  See https://github.com/Malabarba/paradox/issues/95 for an example.

This PR replaces the custom macro with `-when-let` from dash.el, which comes at no additional cost since Ensime already depends upon dash.el anyway–I wonder why `when-let` was defined anyway.

Besides, a package should _never_ define unprefixed symbols, so if `when-let` needs to stay for a reason that I'm not aware of, it needs to be renamed (i.e. `ensime-when-let`).