### PR TITLE
Assembly

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,5 +11,5 @@ build:
 
 matrix:
   EMACS:
-    - /opt/emacs-24.4/bin/emacs
+    - /opt/emacs-24.5/bin/emacs
     - /opt/emacs-24.3/bin/emacs

--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -214,7 +214,7 @@ Analyzer will be restarted."
       (when (file-exists-p classpath-file) (delete-file classpath-file))
       (make-directory (file-name-directory classpath-file) t)
       (ensime-write-to-file buildfile buildcontents)
-      (ensime-write-to-file buildpropsfile "sbt.version=0.13.8\n")
+      (ensime-write-to-file buildpropsfile "sbt.version=0.13.9\n")
 
       (if (executable-find ensime-sbt-command)
           (let ((process (start-process "*ensime-update*" (current-buffer)


### PR DESCRIPTION
this allows a user-provided `-assembly.jar` file of the server to trump the `sbt` update stage. Which has the fortunate side-effect of simplifying the dev cycle.