### PR TITLE
Don't send full source file contents over socket.

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -428,10 +428,7 @@
       (if without-saving
           (save-restriction
             (widen)
-            (ensime-rpc-async-typecheck-file-with-contents
-             buffer-file-name
-             (ensime-get-buffer-as-string)
-             'identity))
+            (ensime-rpc-async-typecheck-buffer 'identity))
         (progn
           (ensime-rpc-async-typecheck-file buffer-file-name 'identity))))))
 

--- a/ensime-util.el
+++ b/ensime-util.el
@@ -195,6 +195,23 @@ Do not show 'Writing..' message."
     (insert-file-contents filename)
     (buffer-string)))
 
+(defun ensime-src-info-with-contents-in-temp ()
+  "Write the contents of current buffer to temp file, return a source-file-info
+ with contents in temp file."
+  (let* ((tmp-dir (concat (ensime--get-cache-dir (ensime-config-for-buffer))
+			  "/scratch"))
+	 (max-rpcs-in-flight 25) ;; random guess...
+	 (tmp-file (format "%s/source_file_contents_%s_%s_%s"
+			   tmp-dir
+			   (emacs-pid)
+			   ensime-connection-counter
+			   (% (ensime-continuation-counter)
+			      max-rpcs-in-flight))))
+    (when (not (file-directory-p tmp-dir))
+      (make-directory tmp-dir t))
+    (ensime-write-buffer tmp-file nil nil)
+    `(:file ,buffer-file-name :contents-in ,tmp-file)))
+
 (defun ensime--dependencies-newer-than-target-p (target-file dep-files-list)
   (if (file-exists-p target-file)
       (let ((target-mtime (nth 5 (file-attributes target-file))))


### PR DESCRIPTION
The sexp protocol parsing layer has trouble with big files. For example a 1000 line java file might take 1+ seconds to parse. This change falls back on an alternative scheme where the source contents are shared via a temporary file. See ensime/ensime-server#1102