### PR TITLE
Fix format string bug containing `%s`

### DIFF
--- a/ensime-notes.el
+++ b/ensime-notes.el
@@ -249,7 +249,7 @@ any buffer visiting the given file."
   (let ((msgs (append (ensime-errors-at (point))
                       (ensime-implicit-notes-at (point)))))
     (when msgs
-      (message (mapconcat 'identity msgs "\n")))))
+      (message "%s" (mapconcat 'identity msgs "\n")))))
 
 (defun ensime-implicit-notes-at (point)
   (cl-labels


### PR DESCRIPTION
If the error attempting to be printed contains a format string like
`%s`, then printing to the minibuffer will fail with the error "Not
enough arguments for format string".

Example of message that caused me to discover the error:
`Implicit conversion of "syncing %s => %s" using augmentString: (x: String)scala.collection.immutable.StringOps`

Minimal emacs-lisp to reproduce issue:

```emacs-lisp
(message (mapconcat 'identity ["%s"] "\n"))
```

vs

```emacs-lisp
(message "%s" (mapconcat 'identity ["%s"] "\n"))
```