### PR TITLE
remove hard auto-complete dependency

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,6 +4,8 @@ build:
     - SCALA_VERSION=2.11.7
   commands:
     - cask pkg-file &&
+      cask install &&
+      cask build &&
       test/run_emacs_tests.sh &&
       if [ -n "$UNDERCOVER" ] && [ -f "coveralls.json" ] ; then
         curl -v -include --form json_file=@coveralls.json https://coveralls.io/api/v1/jobs || true ;

--- a/Cask
+++ b/Cask
@@ -22,8 +22,15 @@
 ;;
 ;;; Code:
 
-(source melpa)
+(source melpa-stable)
 
 (package-file "ensime.el")
+
+(development
+ ;; optional dependencies
+ ;;(depends-on "auto-complete")
+
+ ; genuine dev dependencies
+ (depends-on "undercover"))
 
 ;;; Cask ends here

--- a/ensime-auto-complete.el
+++ b/ensime-auto-complete.el
@@ -25,7 +25,13 @@
 (require 'ensime-completion-util)
 (require 'ensime-model)
 (require 'ensime-util)
-(require 'auto-complete)
+
+;; we don't explicitly depend on auto-complete, this file should
+;; really be released as a separate package.
+;; (require 'auto-complete)
+(autoload 'ac-define-source "auto-complete")
+(autoload 'ac-set-trigger-key "auto-complete")
+(autoload 'auto-complete-mode "auto-complete")
 
 (defcustom ensime-ac-enable-argument-placeholders t
   "If non-nil, insert placeholder arguments in the buffer on completion."

--- a/ensime-company.el
+++ b/ensime-company.el
@@ -28,7 +28,6 @@
 (require 'company)
 (require 'yasnippet)
 (require 'scala-mode2-syntax)
-(require 'auto-complete)
 (require 's)
 (require 'dash)
 

--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -5,6 +5,7 @@
   (require 'ensime-macros))
 
 (require 'dash)
+(require 'popup)
 
 (defvar ensime-compile-result-buffer-name "*ENSIME-Compilation-Result*")
 

--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -1,42 +1,15 @@
-;;; ensime-sbt.el --- SBT support for ENSIME
-;;
-;;;; License
-;;
-;;     Copyright (C) 2008 Raymond Paul Racine
-;;     Portions Copyright (C) Free Software Foundation
-;;     Portions Copyright (C) 2010 Aemon Cannon
-;;
-;;     Authors: Luke Amdor, Raymond Racine, Aemon Cannon
-;;
-;;     This file includes code from slime.el of the SLIME project
-;;     (also licensend under the GNU General Public License.) The
-;;     following copyrights therefore apply:
-;;
-;;     Copyright (C) 2003  Eric Marsden, Luke Gorrie, Helmut Eller
-;;     Copyright (C) 2004,2005,2006  Luke Gorrie, Helmut Eller
-;;     Copyright (C) 2007,2008,2009  Helmut Eller, Tobias C. Rittweiler
-;;
-;;
-;;     This program is free software; you can redistribute it and/or
-;;     modify it under the terms of the GNU General Public License as
-;;     published by the Free Software Foundation; either version 2 of
-;;     the License, or (at your option) any later version.
-;;
-;;     This program is distributed in the hope that it will be useful,
-;;     but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-;;     GNU General Public License for more details.
-;;
-;;     You should have received a copy of the GNU General Public
-;;     License along with this program; if not, write to the Free
-;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
-;;     MA 02111-1307, USA.
+;;; ensime-sbt.el --- SBT support for ENSIME -*- lexical-binding: t -*-
 
+;; Copyright (C) 2015 ENSIME authors
+;; License: http://www.gnu.org/licenses/gpl.html
 
-;; Support for running sbt in inferior mode.
-;; 20090918 Suggestions from Florian Hars
-;; - Removed global manipulations.
-;; - Removed colorization attempts to use base sbt anis colorization.
+;;; Commentary:
+;;
+;;  SBT should be an optional system dependency of ENSIME (we try to
+;;  be build tool agnostic, even if we have a favourite) and ideally
+;;  all sbt-related content should be contained to this file.
+;;
+;;; Code:
 
 (eval-when-compile
   (require 'cl)
@@ -111,6 +84,4 @@
 
 (provide 'ensime-sbt)
 
-;; Local Variables:
-;; End:
-
+;;; ensime-sbt.el ends here

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -160,7 +160,9 @@ where SYMBOL-TYPE is one of:
   :group 'ensime-ui)
 
 (defcustom ensime-completion-style 'company
-  "Should be one of 'company, 'auto-complete or nil."
+  "Should be one of 'company, 'auto-complete or nil.
+`company' is the most stable choice and if `auto-complete' is
+used it must be installed separately."
   :type 'symbol
   :group 'ensime-ui)
 

--- a/ensime.el
+++ b/ensime.el
@@ -6,7 +6,7 @@
 ;; Homepage: https://github.com/ensime/ensime-emacs
 ;; Keywords: languages
 ;; Package-Version:  0.9.10
-;; Package-Requires: ((scala-mode2 "0.21") (sbt-mode "0.03") (popup "0.5.0") (yasnippet "0.8.0") (company "0.8.7") (auto-complete "1.5.0") (dash "2.10.0") (s "1.3.0"))
+;; Package-Requires: ((scala-mode2 "0.22") (sbt-mode "0.1") (yasnippet "0.9.0.1") (company "0.8.12") (dash "2.11.0") (s "1.10.0") (popup "0.5.3"))
 
 ;;; Commentary:
 ;;
@@ -15,10 +15,6 @@
 ;;  not possible with emacs-lisp pattern matching.
 ;;
 ;;; Code:
-
-(eval-and-compile
-  (when (<= emacs-major-version 21)
-    (error "Ensime requires Emacs 22 or higher")))
 
 (eval-and-compile
   (require 'cl)
@@ -35,16 +31,13 @@
 (require 'hideshow)
 (require 'flymake)
 (require 'font-lock)
-(require 'auto-complete)
 (require 'easymenu)
 (require 'ensime-client)
 (require 'ensime-util)
 (require 'ensime-vars)
 (require 'ensime-config)
 (require 'ensime-completion-util)
-(require 'ensime-auto-complete)
-(require 'ensime-company)
-(require 'ensime-sbt)
+
 (require 'ensime-inf)
 (require 'ensime-stacktrace)
 (require 'ensime-debug)
@@ -64,6 +57,14 @@
 (require 'ensime-ui)
 (require 'ensime-http)
 (require 'timer)
+
+;; should really be optional
+(require 'ensime-sbt)
+
+;; autoload ensime-ac-enable and ensime-company-enable so that the
+;; user can select which backend to use without loading both.
+(autoload 'ensime-company-enable "ensime-company")
+(autoload 'ensime-ac-enable "ensime-auto-complete")
 
 (defvar ensime-protocol-version "0.7")
 

--- a/test/run_emacs_tests.sh
+++ b/test/run_emacs_tests.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# NOTE: check the .drone.yml file for the cask commands that are
+# needed to initialise your environment.
+
+# TODO: it would be good to rewrite all our tests using standard
+# ert-runner (and lose our custom test start scripts), but that is
+# very tricky because of our async testing. We could turn each of our
+# tests into an ert-deftest but that requires some macro expertise.
+
 # tests must be run from the parent of the test directory
 cd "`dirname $0`/../"
 


### PR DESCRIPTION
This isn't the PR that I really wanted to submit in this area, because I think there is a lot more can be done on separating out the sbt dependency... so I left it as a required (not optional) dependency and raised #253 

The motivation for this PR is that I want to reduce the dependencies to make it easier to bring ENSIME into corporate environments (most notably, **my** corporate environment).

Making `auto-complete` optional is a bit of a hack... it seems that neither `cask` nor emacs package really understand the concept of an optional dependency. So here's the hack:

* remove `auto-complete` from the dependency list
* add it to the `Cask` file as a developer dependency so that it is available for testing (actually we don't have any tests for it, so this is blank)
* remove all `(require 'ensime-auto-complete)` and replace with autoloads for the useful function
* remove all `(require 'auto-complete)` and replace them with autoloads for the functions that we need, allowing `package` to compile the files on desktops that **don't** have `auto-complete` installed

I tested this on a pristine Emacs install with and without `auto-complete` installed. Without, `ensime` compiled and the user gets an error if they select `auto-complete` completion style but don't have it installed. With, everything works as expected.

After discussing on the `#emacs` IRC channel, people tend to publish multiple packages to deal with optional components. That seems a bit heavy, so maybe this is a hack we're happy enough with.

Oh, one new testing feature: we now use cask to compile the lisp files (which serves as a lint stage that we're ignoring) and to download all our dependencies from MELPA stable.