### PR TITLE
delete duplicate classpath entries

### DIFF
--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -175,11 +175,11 @@ the current project's dependencies. Returns list of form (cmd [arg]*)"
          :java (concat (plist-get config :java-home) "/bin/java")
          :java-flags (or (plist-get config :java-flags) ensime-default-java-flags)
          :classpath (ensime--build-classpath
-                     (apply #'append
-                            (ensime--scan-classpath (ensime-read-from-file (ensime--classpath-file (plist-get config :scala-version)))
-                                                    "\\(scala-compiler\\|scala-reflect\\)-[.[:digit:]]+\\.jar$")
-                            (funcall get-deps config)
-                            (mapcar get-deps (plist-get config :subprojects)))))
+                     (delete-dups (apply #'append
+                                         (ensime--scan-classpath (ensime-read-from-file (ensime--classpath-file (plist-get config :scala-version)))
+                                                                 "\\(scala-compiler\\|scala-reflect\\)-[.[:digit:]]+\\.jar$")
+                                         (funcall get-deps config)
+                                         (mapcar get-deps (plist-get config :subprojects))))))
       (error "No ensime config available"))))
 
 (defun ensime-inf-switch ()


### PR DESCRIPTION
When using ensime with multiple submodules with overlapping
dependencies, I was finding that the exact same jars were being added
multiple times to the classpath. Java doesn't consider this an issue,
but the classpath was long enough due to this issue to exceed the
maximum size allowed for bash on my machine (argument list too long exception).

This is not actually a proper fix for the args list being too long, but should prevent it from happening quite so often.