### PR TITLE
Performance fix when typechecking

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -411,8 +411,7 @@
 ;; Compilation on request
 
 (defun ensime-typecheck-current-file (&optional without-saving)
-  "Send a request for re-typecheck of current buffer to all ENSIME servers
- managing projects that contains the current buffer. By default, the buffer
+  "Re-typecheck the current buffer. By default, the buffer
  is saved first if it has unwritten modifications. With a prefix argument,
  the buffer isn't saved, instead the contents of the buffer is sent to the
  typechecker."
@@ -421,16 +420,13 @@
   (when (and (not without-saving) (buffer-modified-p))
     (ensime-write-buffer nil t))
 
-  ;; Send the reload request to all servers that might be interested.
-  (dolist (con (ensime-connections-for-source-file buffer-file-name t))
-    (setf (ensime-last-typecheck-run-time con) (float-time))
-    (let ((ensime-dispatching-connection con))
-      (if without-saving
-          (save-restriction
-            (widen)
-            (ensime-rpc-async-typecheck-buffer 'identity))
-        (progn
-          (ensime-rpc-async-typecheck-file buffer-file-name 'identity))))))
+  (setf (ensime-last-typecheck-run-time (ensime-connection)) (float-time))
+  (if without-saving
+      (save-restriction
+        (widen)
+        (ensime-rpc-async-typecheck-buffer 'identity))
+    (progn
+      (ensime-rpc-async-typecheck-file buffer-file-name 'identity))))
 
 (defun ensime-reload-open-files ()
   "Make the ENSIME server forget about all files ; reload .class files

--- a/ensime-util.el
+++ b/ensime-util.el
@@ -129,16 +129,16 @@ argument is supplied) is a .scala or .java file."
  nil, where ensime-path-includes-dir-p will answer t.
  Note: This function assumes both file and dir actually exist."
   (let ((phys-dir (file-truename dir))
-	(d (file-name-directory (expand-file-name file))))
-   (catch 'return
+        (d (file-name-directory (expand-file-name file))))
+    (catch 'return
       (while d
-	(let ((prev d))
-	  (when (string-prefix-p phys-dir (file-truename d))
-	    (throw 'return t))
-	  (setq d (file-name-directory (directory-file-name d)))
-	  (when (equal d prev)
-	    (throw 'return nil))
-	  )))))
+        (let ((prev d))
+          (when (string-prefix-p phys-dir (file-truename d))
+            (throw 'return t))
+          (setq d (file-name-directory (directory-file-name d)))
+          (when (equal d prev)
+            (throw 'return nil))
+          )))))
 
 ; TODO deprecate and rewrite callers to use the cache-dir
 (defun ensime-temp-directory ()


### PR DESCRIPTION
`ensime-config-includes-source-file` is pretty expensive, and was called before every automatic typecheck. For projects with large configs such as ensime itself, I was seeing emacs freeze for 0.5s .

The fix here is to minimize calls to `ensime-config-includes-source-file` by assuming that a file can belong to only one ensime connection. I think that's a pretty reasonable assumption. Let me know if you disagree and I'll think of some other solution.
