### PR TITLE
Misc. fixes to make ensime play better with a big, pure java project.

### DIFF
--- a/ensime-auto-complete.el
+++ b/ensime-auto-complete.el
@@ -77,7 +77,6 @@ be used later to give contextual help when entering arguments."
   (let* (;; When called by auto-complete-mode, grab from dynamic environment.
 	 (candidate (or candidate-in candidate))
 	 (name candidate)
-	 (type-id (get-text-property 0 'type-id candidate))
 	 (is-callable (get-text-property 0 'is-callable candidate))
 	 (to-insert (get-text-property 0 'to-insert candidate))
 	 (name-start-point (- (point) (length name))))
@@ -88,11 +87,12 @@ be used later to give contextual help when entering arguments."
       (delete-char (- (length name)))
       (insert to-insert))
 
-    ;; If this member is callable, use the type-id to lookup call completion
+    ;; If this member is callable, lookup call completion
     ;; information to show parameter hints.
     (when is-callable
 
-      (let* ((call-info (ensime-rpc-get-call-completion type-id))
+      (let* ((call-info (ensime-call-completion-info
+			 candidate (ensime-scala-file-p buffer-file-name)))
 	     (param-sections (ensime-type-param-sections call-info)))
 	(when (and call-info param-sections)
 

--- a/ensime-client.el
+++ b/ensime-client.el
@@ -1151,4 +1151,3 @@ copies. All other objects are used unchanged. List must not contain cycles."
 
 ;; Local Variables:
 ;; End:
-

--- a/ensime-company.el
+++ b/ensime-company.el
@@ -133,12 +133,12 @@
   (let* (;; When called by auto-complete-mode, grab from dynamic environment.
 	 (candidate (or candidate-in candidate))
 	 (name candidate)
-	 (type-id (get-text-property 0 'type-id candidate))
 	 (is-callable (get-text-property 0 'is-callable candidate))
 	 (to-insert (get-text-property 0 'to-insert candidate))
 	 (name-start-point (- (point) (length name)))
 	 (call-info
-	  (when is-callable (ensime-rpc-get-call-completion type-id)))
+	  (when is-callable (ensime-call-completion-info
+			     candidate (ensime-scala-file-p buffer-file-name))))
 	 (param-sections
 	  (when is-callable
 	    (-filter
@@ -152,7 +152,6 @@
 			     (car param-sections) :params)))
 	       (null (string-match "[A-z]" name))))
 	 (is-field-assigner (s-ends-with? "_=" name)))
-
 
     (when is-field-assigner
       (delete-char (- 2))

--- a/ensime-completion-util.el
+++ b/ensime-completion-util.el
@@ -124,6 +124,30 @@
 		   (string= prefix (car candidates)))
 	  (car candidates))))))
 
+(defun ensime-call-completion-info (candidate is-scala)
+  "Returns a call-completion-info for the candidate, including details
+ required for expanding a parameter template."
+  (if is-scala
+      ;; Scala case is trivial: request the info by type id
+      (ensime-rpc-get-call-completion (get-text-property 0 'type-id candidate))
+
+    ;; TODO until we sort out ensime-rpc-get-call-completion
+    ;; for Java, use the candidate signature instead as a poor man's
+    ;; call completion info.
+    (let ((type-sig (get-text-property 0 'type-sig candidate)))
+      (let* ((sections (car type-sig))
+	     (return-type (cadr type-sig)))
+	`(:param-sections
+	  ,(mapcar
+	    (lambda (section)
+	      (list :params
+		    (mapcar
+		     (lambda (p) (let ((name (car p))
+				       (type-name (cadr p)))
+				   `(,name (:name ,type-name
+						  :full-name ,type-name))))
+		     section))) sections))))))
+
 (provide 'ensime-completion-util)
 
 ;; Local Variables:

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -109,23 +109,25 @@
 
 (defun ensime-run-after-save-hooks ()
   "Things to run whenever a source buffer is saved."
-  (when (and (ensime-connected-p) (ensime-analyzer-ready))
-    (condition-case err-info
-        (run-hooks 'ensime-source-buffer-saved-hook)
-      (error
-       (message
-        "Error running ensime-source-buffer-saved-hook: %s"
-        err-info)))))
+  (when (ensime-source-file-p)
+    (when (and (ensime-connected-p) (ensime-analyzer-ready))
+      (condition-case err-info
+          (run-hooks 'ensime-source-buffer-saved-hook)
+        (error
+         (message
+          "Error running ensime-source-buffer-saved-hook: %s"
+          err-info))))))
 
 (defun ensime-run-find-file-hooks ()
   "Things to run whenever a source buffer is opened."
-  (when (and (ensime-connected-p) (ensime-analyzer-ready))
-    (condition-case err-info
-        (run-hooks 'ensime-source-buffer-loaded-hook)
-      (error
-       (message
-        "Error running ensime-source-buffer-loaded-hook: %s"
-        err-info)))))
+  (when (ensime-source-file-p)
+    (when (and (ensime-connected-p) (ensime-analyzer-ready))
+      (condition-case err-info
+          (run-hooks 'ensime-source-buffer-loaded-hook)
+        (error
+         (message
+          "Error running ensime-source-buffer-loaded-hook: %s"
+          err-info))))))
 
 (defun ensime-save-buffer-no-hooks ()
   "Just save the buffer per usual, don't type-check!"

--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -121,7 +121,7 @@
      (mapcar 'car ensime-sem-high-faces)
      `(lambda (info)
         (ensime-sem-high-clear-region ,beg ,end)
-        (ensime-sem-high-apply-properties info)
+        (when info (ensime-sem-high-apply-properties info))
         (ensime-event-sig :region-sem-highlighted nil)))))
 
 (defun ensime-sem-high-inspect-highlight ()
@@ -148,4 +148,3 @@
 
 ;; Local Variables:
 ;; End:
-

--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -110,7 +110,7 @@ saveClasspathTask := {
          (scala-version (plist-get config :scala-version))
          (server-env (or (plist-get config :server-env) ensime-default-server-env))
          (buffer (or (plist-get config :buffer) (concat ensime-default-buffer-prefix name)))
-         (server-java (file-name-as-directory (plist-get config :java-home)))
+         (server-java (file-name-as-directory (ensime--get-java-home config)))
          (server-flags (or (plist-get config :java-flags) ensime-default-java-flags)))
     (make-directory cache-dir 't)
 
@@ -126,6 +126,7 @@ saveClasspathTask := {
            (host "127.0.0.1")
            (port-fn (lambda () (ensime--read-portfile
                              (concat cache-dir "/port")))))
+
 
       ;; Surface the server buffer so user can observe the startup progress.
       (display-buffer (process-buffer server-proc) nil)


### PR DESCRIPTION
* Add a temporary adaptor function to make param expansion work for
  java. Completion is *nice* in java now :-)

* Document (with error) that java home is required in config. This was always the case, but we died with a crap message.

* Don't try to fan out typecheck requests to multiple connections. This
  triggers expensive connection-for-sourcefile lookups that choke when
  there are *many* source roots.

* Guard our find-file and save-file hooks with ensime-source-file-p. We
  were previously taxing *all* buffers with expensive connection
  lookups.

* Handle nil semantic highlighting (a hack really).