### PR TITLE
ensime-server will soon depend on netbeans jars

### DIFF
--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -39,21 +39,25 @@ scalaVersion := \"_scala_version_\"
 
 ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
 
+// we don't need jcenter, so this speeds up resolution
+fullResolvers -= Resolver.jcenterRepo
+
 // allows local builds of scala
 resolvers += Resolver.mavenLocal
 
+// for java support
+resolvers += \"NetBeans\" at \"http://bits.netbeans.org/nexus/content/groups/netbeans\"
+
+// this is where the ensime-server snapshots are hosted
 resolvers += Resolver.sonatypeRepo(\"snapshots\")
-
-resolvers += \"Typesafe repository\" at \"http://repo.typesafe.com/typesafe/releases/\"
-
-resolvers += \"Akka Repo\" at \"http://repo.akka.io/repository\"
 
 libraryDependencies += \"org.ensime\" %% \"ensime\" % \"_server_version_\"
 
 dependencyOverrides ++= Set(
   \"org.scala-lang\" % \"scala-compiler\" % scalaVersion.value,
-  \"org.scala-lang\" % \"scalap\" % scalaVersion.value,
-  \"org.scala-lang\" % \"scala-reflect\" % scalaVersion.value
+  \"org.scala-lang\" % \"scala-library\" % scalaVersion.value,
+  \"org.scala-lang\" % \"scala-reflect\" % scalaVersion.value,
+  \"org.scala-lang\" % \"scalap\" % scalaVersion.value
 )
 
 val saveClasspathTask = TaskKey[Unit](\"saveClasspath\", \"Save the classpath to a file\")


### PR DESCRIPTION
@rorygraves @hedefalk @yazgoo this is an update to the `build.sbt` file that we use to download ensime-server and its dependencies. Can you please update your variants of this launcher, as the next PR to be merged into master will need the netbeans repo (and I bet you were probably missing some of the finer details anyway, because I forgot to put them in the reference launch script!)