### PR TITLE
Only require expand region core

### DIFF
--- a/ensime-expand-region.el
+++ b/ensime-expand-region.el
@@ -19,7 +19,7 @@
 (require 'ensime-mode)
 (require 'ensime-client)
 (require 'ensime-editor)
-(require 'expand-region)
+(require 'expand-region-core)
 
 (defun ensime-expand-region-mark-syntactic-context ()
   "Mark the next outer syntactic context."


### PR DESCRIPTION
That's enough to provide the variable definition.  There's no need to load all of Expand Region.