### PR TITLE
Don't attempt to highlight missing files.

### DIFF
--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -117,7 +117,8 @@
 
 (defun ensime-sem-high-refresh-region (beg end)
   "Refresh semantic highlighting for the given region."
-  (when ensime-sem-high-enabled-p
+  (when (and ensime-sem-high-enabled-p
+	     (file-exists-p buffer-file-name))
     (ensime-rpc-symbol-designations
      buffer-file-name (ensime-externalize-offset beg) (ensime-externalize-offset end)
      (mapcar 'car ensime-sem-high-faces)


### PR DESCRIPTION
Temporary fix for #283. The proper fix will accept SourceFileInfo on the server, so we don't need to require a disk file.