### PR TITLE
Changed the implicit conversion and implicit parameter highlight

### DIFF
--- a/ensime-notes.el
+++ b/ensime-notes.el
@@ -146,8 +146,8 @@ any buffer visiting the given file."
 (defface ensime-implicit-highlight
   (if (facep 'flymake-infoline)
       '((t (:inherit flymake-infoline)))
-  '((((supports :underline (:style wave)))
-     :underline (:style wave :color "blue"))
+  '((((supports :underline (:style line)))
+     :underline (:style line :color "light gray"))
     (t :inherit flymake-warnline)))
   "Face used for marking a region where an implicit conversion was applied."
   :group 'ensime-ui)


### PR DESCRIPTION
Changed the implicit conversion and implicit parameter highlight to be a little less in-your-face: light gray straight underline.