### PR TITLE
Fix for #247 - remove the noisy gutter icon for implicits

### DIFF
--- a/ensime-semantic-highlight.el
+++ b/ensime-semantic-highlight.el
@@ -41,8 +41,9 @@
               (setq start end)
               (setq end (1+ end)))
 	    (let ((ov (make-overlay start end buf)))
-              (when (or (eq type 'implicitParams)
-                        (eq type 'implicitConversion))
+	      (when (and ensime-implicit-gutter-icons
+			 (or (eq type 'implicitParams)
+			     (eq type 'implicitConversion)))
                 (overlay-put ov 'before-string
                              (propertize "."
                                          'display

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -231,6 +231,12 @@ name (case sensitive), and CONFIG-PLIST has the same format as
   :type 'alist
   :group 'ensime-ui)
 
+(defcustom ensime-implicit-gutter-icons t
+  "If non-nil, Ensime will provide gutter icons for implicit conversions
+and parameters."
+  :type 'boolean
+  :group 'ensime-ui)
+
 (provide 'ensime-vars)
 
 ;; Local Variables:


### PR DESCRIPTION
Remove the noisy gutter icon for implicit parameters and conversions.

They're underlined anyway.