### PR TITLE
Allow scala-compiler version omission in classpath

### DIFF
--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -185,7 +185,7 @@ the current project's dependencies. Returns list of form (cmd [arg]*)"
          :classpath (ensime--build-classpath
                      (delete-dups (apply #'append
                                          (ensime--scan-classpath (ensime-read-from-file (ensime--classpath-file (plist-get config :scala-version)))
-                                                                 "\\(scala-compiler\\|scala-reflect\\)-[.[:digit:]]+\\.jar$")
+                                                                 "\\(scala-compiler\\|scala-reflect\\)\\(-[.[:digit:]]+\\)?\\.jar$")
                                          (funcall get-deps config)
                                          (mapcar get-deps (plist-get config :subprojects))))))
       (error "No ensime config available"))))


### PR DESCRIPTION
This patch changes the regexp for matching scala-compiler and scala-reflect jars in the classpath so that it also matches jars without a version number in their names.