### PR TITLE
Add basic support for diff refactoring

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -1072,6 +1072,16 @@ copies. All other objects are used unchanged. List must not contain cycles."
      `(swank:prepare-refactor
        ,proc-id ,refactor-type ,params ,(not non-interactive)) continue)))
 
+(defun ensime-rpc-refactor-diff
+    (proc-id params non-interactive continue blocking)
+  (if blocking
+      (ensime-eval
+       `(swank:diff-refactor
+         ,proc-id ,params ,(not non-interactive)))
+    (ensime-eval-async
+     `(swank:diff-refactor
+       ,proc-id, params ,(not non-interactive)) continue)))
+
 (defun ensime-rpc-refactor-exec (proc-id refactor-type continue)
   (ensime-eval-async `(swank:exec-refactor ,proc-id , refactor-type) continue))
 
@@ -1088,7 +1098,7 @@ copies. All other objects are used unchanged. List must not contain cycles."
 		     continue))
 
 (defun ensime-rpc-async-symbol-designations-for-buffer (start end requested-types continue)
-  (let ((file (cond ((version<= "0.8.18" (ensime-protocol-version))
+  (let ((file (cond ((version<= "0.8.19" (ensime-protocol-version))
 		     (ensime-src-info-for-current-buffer))
 		    (t buffer-file-name))))
     (ensime-eval-async `(swank:symbol-designations ,file ,start ,end ,requested-types)

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -75,11 +75,21 @@
       (define-key prefix-map (kbd "C-d q") 'ensime-db-quit)
       (define-key prefix-map (kbd "C-d l") 'ensime-db-list-locals)
 
-      (define-key prefix-map (kbd "C-r r") 'ensime-refactor-rename)
-      (define-key prefix-map (kbd "C-r o") 'ensime-refactor-organize-imports)
-      (define-key prefix-map (kbd "C-r l") 'ensime-refactor-extract-local)
-      (define-key prefix-map (kbd "C-r m") 'ensime-refactor-extract-method)
-      (define-key prefix-map (kbd "C-r i") 'ensime-refactor-inline-local)
+      (define-key prefix-map (kbd "C-r r") (if ensime-refactor-enable-beta
+                                               'ensime-refactor-diff-rename
+                                             'ensime-refactor-rename))
+      (define-key prefix-map (kbd "C-r o") (if ensime-refactor-enable-beta
+                                               'ensime-refactor-diff-organize-imports
+                                             'ensime-refactor-organize-imports))
+      (define-key prefix-map (kbd "C-r l") (if ensime-refactor-enable-beta
+                                               'ensime-refactor-diff-extract-local
+                                             'ensime-refactor-extract-local))
+      (define-key prefix-map (kbd "C-r m") (if ensime-refactor-enable-beta
+                                               'ensime-refactor-diff-extract-method
+                                             'ensime-refactor-extract-method))
+      (define-key prefix-map (kbd "C-r i") (if ensime-refactor-enable-beta
+                                               'ensime-refactor-diff-inline-local
+                                             'ensime-refactor-inline-local))
       (define-key prefix-map (kbd "C-r t") 'ensime-import-type-at-point)
 
       (define-key map ensime-mode-key-prefix prefix-map)
@@ -167,12 +177,22 @@
      ["Show all errors and warnings" ensime-show-all-errors-and-warnings])
 
     ("Refactor"
-     ["Organize imports" ensime-refactor-organize-imports]
+     ["Organize imports" (if ensime-refactor-enable-beta
+                             (ensime-refactor-diff-organize-imports)
+                           (ensime-refactor-organize-imports))]
      ["Import type at point" ensime-import-type-at-point]
-     ["Rename" ensime-refactor-rename]
-     ["Extract local val" ensime-refactor-extract-local]
-     ["Extract method" ensime-refactor-extract-method]
-     ["Inline local val" ensime-refactor-inline-local])
+     ["Rename" (if ensime-refactor-enable-beta
+                   (ensime-refactor-diff-rename)
+                 (ensime-refactor-rename))]
+     ["Extract local val" (if ensime-refactor-enable-beta
+                              (ensime-refactor-diff-extract-local)
+                            (ensime-refactor-extract-local))]
+     ["Extract method" (if ensime-refactor-enable-beta
+                           (ensime-refactor-diff-extract-method)
+                         (ensime-refactor-extract-method))]
+     ["Inline local val" (if ensime-refactor-enable-beta
+                             (ensime-refactor-diff-inline-local)
+                           (ensime-refactor-inline-local))])
 
     ("Navigation"
      ["Lookup definition" ensime-edit-definition]

--- a/ensime-refactor.el
+++ b/ensime-refactor.el
@@ -23,6 +23,8 @@
   (require 'cl)
   (require 'ensime-macros))
 
+(require 'diff-mode)
+
 (defvar ensime-refactor-id-counter 0
   "Each refactoring is given a unique id.")
 
@@ -205,6 +207,156 @@
 	(insert "Nothing to be done.")
       (ensime-insert-change-list changes))))
 
+(defun ensime-refactor-diff-rename (&optional new-name)
+  "Rename a symbol, project-wide."
+  (interactive)
+  (let ((sym (ensime-sym-at-point)))
+    (if sym
+        (let* ((start (plist-get sym :start))
+               (end (plist-get sym :end))
+               (old-name (plist-get sym :name))
+               (name (or new-name
+                         (read-string (format "Rename '%s' to: " old-name)))))
+          (ensime-refactor-diff
+           'rename
+           `(file ,buffer-file-name
+                  start ,(ensime-externalize-offset start)
+                  end ,(ensime-externalize-offset end)
+                  newName ,name)))
+      (message "Please place cursor on a symbol."))))
+
+(defun ensime-refactor-diff-organize-imports ()
+  "Do a syntactic organization of the imports in the current buffer."
+  (interactive)
+  (cond ((ensime-visiting-java-file-p)
+         (ensime-refactor-organize-java-imports)
+         (message "Organized."))
+        (t
+         (ensime-refactor-diff
+          'organizeImports
+          `(file ,buffer-file-name)))))
+
+(defun ensime-refactor-diff-extract-local ()
+  "Extract a range of code into a val."
+  (interactive)
+  (let ((name (read-string "Name of local value: ")))
+    (destructuring-bind (start end)
+        (ensime-computed-range)
+      (ensime-refactor-diff
+       'extractLocal
+       `(file ,buffer-file-name
+              start ,start
+              end ,end
+              name ,name)))))
+
+(defun ensime-refactor-diff-extract-method ()
+  "Extract a range of code into a method."
+  (interactive)
+  (let ((name (read-string "Name of method: ")))
+    (destructuring-bind (start end)
+        (ensime-computed-range)
+      (ensime-refactor-diff
+       'extractMethod
+       `(file ,buffer-file-name
+              start ,start
+              end ,end
+              methodName ,name)))))
+
+(defun ensime-refactor-diff-inline-local ()
+  "Get rid of an intermediate variable."
+  (interactive)
+  (let ((sym (ensime-sym-at-point)))
+    (if sym
+        (let* ((start (plist-get sym :start))
+               (end (plist-get sym :end)))
+          (ensime-refactor-diff
+           'inlineLocal
+           `(file ,buffer-file-name
+                  start ,(ensime-externalize-offset start)
+                  end ,(ensime-externalize-offset end))))
+      (message "Please place cursor on a local value."))))
+
+(defun ensime-refactor-diff (refactor-type params &optional non-interactive blocking)
+  (if (buffer-modified-p) (ensime-write-buffer nil t))
+  (incf ensime-refactor-id-counter)
+  (if (not blocking) (message "Please wait..."))
+  (ensime-rpc-refactor-diff
+   ensime-refactor-id-counter
+   params
+   non-interactive
+   'ensime-refactor-diff-handler
+   blocking))
+
+(defun ensime-refactor-diff-handler (result)
+  (let ((refactor-type (plist-get result :refactor-type))
+        (id (plist-get result :procedure-id))
+        (diff (plist-get result :diff)))
+    (pcase (list ensime-refactor-preview
+                 (ensime--refactor-diff-auto-apply-type-p refactor-type)
+                 (ensime--refactor-diff-auto-apply-file-p diff)
+                 (ensime--refactor-diff-auto-apply-hunk-p diff))
+      (`(nil ,_ ,_ ,_)       (ensime-refactor-diff-apply-silently diff))
+      (`(,_ nil nil nil)   (ensime-refactor-diff-preview-popup diff))
+      (_                  (ensime-refactor-diff-preview-apply-popup diff)))
+    (delete-file diff)
+    (ensime-event-sig :refactor-diff-done diff)))
+
+(defun ensime-refactor-diff-preview-popup (diff)
+  (ensime-with-popup-buffer (ensime-refactor-info-buffer-name
+                             nil t 'diff-mode)
+                            (insert-file-contents diff)))
+
+(defun ensime-refactor-diff-preview-apply-popup (diff)
+  (ensime-with-popup-buffer (ensime-refactor-info-buffer-name
+                             nil nil 'diff-mode)
+                            (insert-file-contents diff)
+                            (ensime-refactor-diff-apply-hunks)
+                            (ensime-refactor-diff-save-source-files)))
+
+(defun ensime-refactor-diff-apply-silently (diff)
+  (with-temp-buffer
+    (insert-file-contents diff)
+    (ensime-refactor-diff-apply-hunks)
+    (ensime-refactor-diff-save-source-files)))
+
+(defun ensime--refactor-diff-auto-apply-type-p (refactor-type)
+  (memq refactor-type ensime-refactor-auto-apply-types))
+
+(defun ensime--refactor-diff-auto-apply-file-p (diff)
+  (with-temp-buffer
+    (insert-file-contents diff)
+    (goto-char (point-min))
+    (re-search-forward diff-file-header-re nil t
+                       ensime-refactor-auto-apply-file-limit)))
+
+(defun ensime--refactor-diff-auto-apply-hunk-p (diff)
+  (with-temp-buffer
+    (insert-file-contents diff)
+    (goto-char (point-min))
+    (re-search-forward diff-hunk-header-re nil t
+                       ensime-refactor-auto-apply-hunk-limit)))
+
+(defun ensime-refactor-diff-apply-hunks ()
+  "Apply or undo all hunks in the diff contents of the current buffer."
+  (interactive)
+  (make-local-variable 'diff-advance-after-apply-hunk)
+  (setq diff-advance-after-apply-hunk nil)
+  (goto-char (point-min))
+  (while (re-search-forward diff-hunk-header-re nil t)
+    (diff-apply-hunk)))
+
+(defun ensime-refactor-diff-save-source-files ()
+  "Save all source files from the diff contents of the current buffer.
+Do not asks user about each one if `ensime-refactor-save-with-no-questions' is non-nil."
+  (interactive)
+  (goto-char (point-min))
+  (while (re-search-forward diff-file-header-re nil t)
+    (-when-let (src-buffer-name (buffer-name (car (diff-find-source-location))))
+      (save-some-buffers
+       ensime-refactor-save-with-no-questions
+       (-partial (lambda (src-buffer-name)
+                   (equal src-buffer-name (buffer-name)))
+                 src-buffer-name)))))
 
 
 (provide 'ensime-refactor)

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1540,6 +1540,40 @@
 		     (ensime-test-cleanup proj))))
 
    (ensime-async-test
+    "Test organize imports diff refactoring: remove unused import."
+    (let* ((proj (ensime-create-tmp-project
+                  `((:name
+                     "hello_world.scala"
+                     :contents ,(ensime-test-concat-lines
+                                 "package com.helloworld"
+                                 "import scala.collection.immutable.Vector"
+                                 "class HelloWorld{"
+                                 "}"
+                                 ""))))))
+      (ensime-test-init-proj proj))
+
+    ((:connected))
+    ((:compiler-ready :full-typecheck-finished)
+     (ensime-test-with-proj
+      (proj src-files)
+      (setq ensime-refactor-auto-apply-types '(rename))
+      (setq ensime-refactor-auto-apply-file-limit 0)
+      (setq ensime-refactor-auto-apply-hunk-limit 0)
+      (ensime-refactor-diff-organize-imports)))
+    (:refactor-diff-done diff t
+                            (ensime-test-with-proj
+                             (proj src-files)
+                             (find-file (car src-files))
+                             (let ((src (buffer-substring-no-properties
+                                         (point-min) (point-max))))
+                               (ensime-assert-equal src (ensime-test-concat-lines
+                                                         "package com.helloworld"
+                                                         "class HelloWorld{"
+                                                         "}"
+                                                         "")))
+                             (ensime-test-cleanup proj))))
+
+   (ensime-async-test
     "Test rename refactoring over multiple files."
     (let* ((proj (ensime-create-tmp-project
                   `((:name
@@ -1604,6 +1638,68 @@
       (ensime-assert (null (ensime-all-notes)))
       (ensime-test-cleanup proj))))
 
+   (ensime-async-test
+    "Test rename diff refactoring over multiple files."
+    (let* ((proj (ensime-create-tmp-project
+                  `((:name
+                     "hello_world.scala"
+                     :contents ,(ensime-test-concat-lines
+                                 "package com.helloworld"
+                                 "class /*1*/HelloWorld{"
+                                 "}"
+                                 ""))
+                    (:name
+                     "another.scala"
+                     :contents ,(ensime-test-concat-lines
+                                 "package com.helloworld"
+                                 "object Another {"
+                                 "def main(args:Array[String]) {"
+                                 "val a = new HelloWorld()"
+                                 "}"
+                                 "}"
+                                 ""))))))
+      (ensime-test-init-proj proj))
+    ((:connected))
+    ((:compiler-ready :full-typecheck-finished)
+     (ensime-test-with-proj
+      (proj src-files)
+      ;; refactor-rename needs all files to be typechecked
+      (ensime-typecheck-all)))
+
+    ((:full-typecheck-finished)
+     (ensime-test-with-proj
+      (proj src-files)
+      (ensime-assert (null (ensime-all-notes))))
+     (setq ensime-refactor-auto-apply-types '(rename))
+     (setq ensime-refactor-auto-apply-file-limit 0)
+     (setq ensime-refactor-auto-apply-hunk-limit 0)
+     (goto-char (ensime-test-after-label "1"))
+     (forward-char)
+     (ensime-refactor-diff-rename "DudeFace"))
+
+    (:refactor-diff-done diff t
+                            (ensime-test-with-proj
+                             (proj src-files)
+                             (find-file (car src-files))
+                             (let ((src (buffer-substring-no-properties
+                                         (point-min) (point-max))))
+                               (ensime-assert-equal src (ensime-test-concat-lines
+                                                         "package com.helloworld"
+                                                         "class /*1*/DudeFace{"
+                                                         "}"
+                                                         "")))
+                             (find-file (car (cdr src-files)))
+                             (let ((src (buffer-substring-no-properties
+                                         (point-min) (point-max))))
+                               (ensime-assert-equal src (ensime-test-concat-lines
+                                                         "package com.helloworld"
+                                                         "object Another {"
+                                                         "def main(args:Array[String]) {"
+                                                         "val a = new DudeFace()"
+                                                         "}"
+                                                         "}"
+                                                         "")))
+                             (ensime-test-cleanup proj))))
    (ensime-async-test
     "Test find-references."
     (let* ((proj (ensime-create-tmp-project

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -237,6 +237,48 @@ and parameters."
   :type 'boolean
   :group 'ensime-ui)
 
+(defcustom ensime-refactor-enable-beta nil
+  "If non-nil, Ensime will use diff api for refactoring."
+  :type 'boolean
+  :group 'ensime-ui)
+
+(defcustom ensime-refactor-preview nil
+  "If non-nil, Ensime will show preview of the changes in the
+*ENSIME-Refactoring* buffer."
+  :type 'boolean
+  :group 'ensime-ui)
+
+(defcustom ensime-refactor-auto-apply-file-limit 0
+  "If less or equal to the number of diff source files, Ensime
+will automatically apply hunks. It is used in conjunction with
+`ensime-refactor-auto-apply-hunk-limit' and
+`ensime-refactor-auto-apply-file-limit'."
+  :type 'number
+  :group 'ensime-ui)
+
+(defcustom ensime-refactor-auto-apply-hunk-limit 0
+  "If less or equal to the number of hunks, Ensime will
+automatically apply hunks. It is used in conjunction with
+`ensime-refactor-auto-apply-file-limit' and
+`ensime-refactor-auto-apply-types'."
+  :type 'number
+  :group 'ensime-ui)
+
+(defcustom ensime-refactor-auto-apply-types
+  '(organizeImports)
+  "Automatically apply hunks if the refactor type's in the
+list. It is used in conjunction with
+`ensime-refactor-auto-apply-file-limit' and
+`ensime-refactor-auto-apply-hunk-limit'."
+  :type '(repeat symbol)
+  :group 'ensime-ui)
+
+(defcustom ensime-refactor-save-with-no-questions t
+  "Save buffers affected by refactoring with no confirmation
+questions."
+  :type 'boolean
+  :group 'ensime-ui)
+
 (provide 'ensime-vars)
 
 ;; Local Variables:


### PR DESCRIPTION
This is a rudimentary support for most of ensime refactoring functionality using a new `diff-refactor` request.  The current prepare-exec-cancel refactoring method is not affected by the change.

I guess we need to add some commands on top of the standard `diff-mode` like applying all hunks, deleting diff file when all hunks applied, etc... What do you think?


