### PR TITLE
Ensime Imenu: File structure view

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -1135,6 +1135,10 @@ copies. All other objects are used unchanged. List must not contain cycles."
      t ;; reload
      ) continue))
 
+(defun ensime-rpc-structure-view ()
+  (ensime-eval
+   `(swank:structure-view
+     ,(ensime-src-info-for-current-buffer))))
 
 (provide 'ensime-client)
 

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -291,7 +291,8 @@
           (setq tooltip-delay 1.0)
           (define-key ensime-mode-map [mouse-movement] 'ensime-mouse-motion))
 
-        (ensime-refresh-all-note-overlays))
+        (ensime-refresh-all-note-overlays)
+        (ensime--setup-imenu))
     (progn
       (pcase ensime-completion-style
         (`auto-complete
@@ -319,7 +320,8 @@
 
       (remove-hook 'tooltip-functions 'ensime-tooltip-handler)
       (make-local-variable 'track-mouse)
-      (setq track-mouse nil))))
+      (setq track-mouse nil)
+      (ensime--unset-imenu))))
 
 ;;;;;; Mouse handlers
 
@@ -348,6 +350,17 @@
     (setq tooltip-last-mouse-motion-event (copy-sequence event))
     (tooltip-start-delayed-tip)))
 
+(defun ensime--setup-imenu ()
+  "Setup imenu function and make imenu rescan index with every call."
+  (set (make-local-variable 'backup-imenu-auto-rescan) imenu-auto-rescan)
+  (set (make-local-variable 'backup-imenu-create-index-function) imenu-create-index-function)
+  (set (make-local-variable 'imenu-auto-rescan) t)
+  (set (make-local-variable 'imenu-create-index-function) #'ensime-imenu-index-function))
+
+(defun ensime--unset-imenu ()
+  "Revert ensime specific imenu settings."
+  (setq imenu-auto-rescan backup-imenu-auto-rescan)
+  (setq imenu-create-index-function backup-imenu-create-index-function))
 
 ;;;;;; Tooltips
 

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -2196,6 +2196,44 @@
 
       (ensime-test-cleanup proj))))
 
+
+   (ensime-async-test
+    "Test ensime imenu index function."
+    (let* ((proj (ensime-create-tmp-project
+                  `((:name
+                     "pack/a.scala"
+                     :contents ,(ensime-test-concat-lines
+                                 "package pack"
+                                 "import java.io.File"
+                                 "class Test(val accessor: File)"
+                                 "case class CaseTest(x: String, y: Int)"
+                                 "object Test {"
+                                 "  type TestType[A] = List[A]"
+                                 "  class Nested(val accessor: String)"
+                                 "  case class NestedCase(x: String, y:Int)"
+                                 "  implicit def stringToNested(s: String) = new Nested(s)"
+                                 "}"))))))
+      (ensime-test-init-proj proj))
+
+    ((:connected))
+    ((:compiler-ready :indexer-ready :full-typecheck-finished)
+
+     (ensime-test-with-proj
+      (proj src-files)
+      (find-file (car src-files))
+      (goto-char (point-min))
+      (let ((expected '(("class:Test" . 40)
+                        ("class:CaseTest" . 76)
+                        ("object:Test" . 111)
+                        ("type:Test.TestType" . 125)
+                        ("class:Test.Nested" . 155)
+                        ("class:Test.NestedCase" . 197)
+                        ("def:Test.stringToNested" . 241)))
+	    (imenu-index (ensime-imenu-index-function)))
+	(ensime-assert (not (null imenu-index)))
+	(ensime-assert-equal imenu-index expected))
+      (ensime-test-cleanup proj))))
+
    (ensime-async-test
     "Test implicit notes."
     (let* ((proj (ensime-create-tmp-project


### PR DESCRIPTION
File structure server call implementation, available via `imenu` command, replacing scala-mode2 imenu generators. Menu items are formatted with colon instead of parenthesis, so that different backend for imenu is visible.