### PR TITLE
Update README.md to point to emacs documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 [![Melpa Status](http://melpa.milkbox.net/packages/ensime-badge.svg)](http://melpa.milkbox.net/#/ensime)
 [![Build Status](http://fommil.com/api/badges/ensime/ensime-emacs/status.svg)](http://fommil.com/ensime/ensime-emacs)
 
-Documentation is available at [ensime.org](http://ensime.org/emacs/)
+Documentation is available at [ensime.org](http://ensime.org/editors/emacs/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 [![Melpa Status](http://melpa.milkbox.net/packages/ensime-badge.svg)](http://melpa.milkbox.net/#/ensime)
 [![Build Status](http://fommil.com/api/badges/ensime/ensime-emacs/status.svg)](http://fommil.com/ensime/ensime-emacs)
 
-Documentation is available at [ensime.org](http://ensime.org)
+Documentation is available at [ensime.org](http://ensime.org/emacs/)


### PR DESCRIPTION
The documentation page starts with resources for learning Emacs. Perhaps it's better to start with installation instructions or basic editor use.