### PR TITLE
Changed the error message to point to troubleshooting guide

### DIFF
--- a/ensime.el
+++ b/ensime.el
@@ -87,8 +87,8 @@
              `(lambda (reason) (ensime--maybe-update-and-start-noninteractive ,orig-bfn)))
           (ensime--maybe-update-and-start orig-bfn))
       ('error (error (format
-                      "check that sbt is on your PATH and that your config is compatible with %s [%s]"
-                      "http://github.com/ensime/ensime-server/wiki/Example-Configuration-File" ex))))))
+                      "check that sbt is on your PATH and see the Troubleshooting Guide for further steps %s [%s]"
+                      "http://ensime.github.io/editors/emacs/troubleshooting/" ex))))))
 
 ;;;###autoload
 (defun ensime-remote (host port)


### PR DESCRIPTION
The earlier link pointed to http://github.com/ensime/ensime-server/wiki/Example-Configuration-File
which is now obsolete.