### PR TITLE
Delete existing member when completing.

### DIFF
--- a/ensime-company.el
+++ b/ensime-company.el
@@ -178,6 +178,12 @@
       (delete-char (- (length name)))
       (insert to-insert))
 
+    ;; If we're modifying an existing method identifier, delete what
+    ;; was there before and don't mess with the params.
+    (-when-let (suffix (ensime-completion-suffix-at-point))
+	(delete-char (length suffix))
+	(setq skip-params t))
+
     (when (and is-callable call-info (not skip-params))
       (let* ((maybe-braces (ensime-param-section-accepts-block-p
 			    (car (last param-sections))))

--- a/ensime-completion-util.el
+++ b/ensime-completion-util.el
@@ -94,6 +94,14 @@
       (if (string-match ensime--rev-id-re s)
 	  (s-reverse (match-string 1 s)) ""))))
 
+(defun ensime-completion-suffix-at-point ()
+  "Returns the suffix following point."
+  ;; A bit of a hack: Piggyback on font-lock's tokenization to
+  ;; avoid requesting completions inside comments.
+  (when (not (ensime-in-comment-p (point)))
+    (when (looking-at scala-syntax:plainid-re)
+      (match-string 1))))
+
 (defun ensime-get-completions-async
     (max-results case-sense callback)
   (ensime-rpc-async-completions-at-point max-results case-sense


### PR DESCRIPTION

Candidate fix for #373. This is a pretty aggressive approach where we replace any ident following (point) with the newly completed ident. Whether or not there is a trailing paren.

@fommil I can't decide if this is right, so I'm going to try it at work some. Will you give it a try as well?