### PR TITLE
Add refactor option to add type annotation to current symbol

### DIFF
--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -75,6 +75,7 @@
       (define-key prefix-map (kbd "C-d q") 'ensime-db-quit)
       (define-key prefix-map (kbd "C-d l") 'ensime-db-list-locals)
 
+      (define-key prefix-map (kbd "C-r a") 'ensime-refactor-add-type-annotation)
       (define-key prefix-map (kbd "C-r r") 'ensime-refactor-diff-rename)
       (define-key prefix-map (kbd "C-r o") 'ensime-refactor-diff-organize-imports)
       (define-key prefix-map (kbd "C-r l") 'ensime-refactor-diff-extract-local)
@@ -167,6 +168,7 @@
      ["Show all errors and warnings" ensime-show-all-errors-and-warnings])
 
     ("Refactor"
+     ["Add type annotation" (ensime-refactor-add-type-annotation)]
      ["Organize imports" (ensime-refactor-diff-organize-imports)]
      ["Import type at point" ensime-import-type-at-point]
      ["Rename" (ensime-refactor-diff-rename)]

--- a/ensime-model.el
+++ b/ensime-model.el
@@ -64,6 +64,13 @@
      (plist-get type :full-name)
      (ensime-type-type-args-suffix type))))
 
+(defun ensime-type-short-name-with-args (type)
+  (if (plist-get type :arrow-type)
+      (plist-get type :name)
+    (concat
+     (plist-get type :name)
+     (ensime-type-type-args-suffix type))))
+
 (defun ensime-type-type-args-suffix (type)
   (let ((args (ensime-type-type-args type)))
     (if args

--- a/ensime-refactor.el
+++ b/ensime-refactor.el
@@ -232,6 +232,17 @@ Do not asks user about each one if `ensime-refactor-save-with-no-questions' is n
                    (equal src-buffer-name (buffer-name)))
                  src-buffer-name)))))
 
+(defun ensime-refactor-add-type-annotation ()
+  "Add type annotation to current symbol."
+  (interactive)
+  (let* ((type (ensime-rpc-get-type-at-point))
+         (shortname (ensime-type-short-name-with-args type)))
+    (save-excursion
+      (forward-word)
+      (while (let ((current-char (thing-at-point 'char)))
+               (or (equal "(" current-char) (equal "[" current-char)))
+        (forward-list))
+      (insert (concat ": " shortname)))))
 
 (provide 'ensime-refactor)
 

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1684,6 +1684,51 @@
 
       (ensime-test-cleanup proj))))
 
+      (ensime-async-test
+    "Test add type annotation."
+    (let* ((proj (ensime-create-tmp-project
+                  `((:name
+                     "d.scala"
+                     :contents ,(ensime-test-concat-lines
+                                 "class D {"
+                                 "  val /*2*/a = true"
+                                 "  def /*3*/b = 99"
+                                 "  def /*4*/test2() = 99"
+                                 "  def /*5*/test3(x: Int) = 99"
+                                 "  def /*6*/test4(x: Int = 99) = 99"
+                                 "  def /*7*/test5(x: Int = 99)(implicit y: Int) = y"
+                                 "}"))))))
+      (ensime-test-init-proj proj))
+
+    ((:connected))
+    ((:compiler-ready :full-typecheck-finished :indexer-ready)
+     (ensime-test-with-proj
+      (proj src-files)
+
+      (goto-char (ensime-test-after-label "7"))
+      (ensime-refactor-add-type-annotation)
+      (goto-char (ensime-test-after-label "6"))
+      (ensime-refactor-add-type-annotation)
+      (goto-char (ensime-test-after-label "5"))
+      (ensime-refactor-add-type-annotation)
+      (goto-char (ensime-test-after-label "4"))
+      (ensime-refactor-add-type-annotation)
+      (goto-char (ensime-test-after-label "3"))
+      (ensime-refactor-add-type-annotation)
+      (goto-char (ensime-test-after-label "2"))
+      (ensime-refactor-add-type-annotation)
+
+      (goto-char 1)
+      (ensime-assert (search-forward "a: Boolean =" nil t))
+      (ensime-assert (search-forward "b: Int =" nil t))
+      (ensime-assert (search-forward "test2(): Int =" nil t))
+      (ensime-assert (search-forward "test3(x: Int): Int =" nil t))
+      (ensime-assert (search-forward "test4(x: Int = 99): Int =" nil t))
+      (ensime-assert (search-forward "test5(x: Int = 99)(implicit y: Int): Int =" nil t))
+
+      (ensime-test-cleanup proj)
+      )))
+
    (ensime-async-test
     "Test debugging scala project."
     (let* ((proj (ensime-create-tmp-project


### PR DESCRIPTION
Add refactor option to add type annotation to current symbol

Mapped to `C-c C-r a`

Fixes https://github.com/ensime/ensime-emacs/issues/379

![Demo](https://cldup.com/5_KiKW66BU.gif)

Tested with the following examples:
```scala
  private val startTime = startDate.toDateTimeAtStartOfDay.getMillis
  private val endTime = endDate.toDateTimeAtStartOfDay.getMillis

  for {
    a <- List(1, 2)
    b <- Map(1 -> 1)
    (c, d) <- Map("" -> true)
  } yield 1

  def test = 1
  def test2() = 1
  def test3(x: Int) = 1
  def test4(x: Int = 3) = 1
  def test5(x: Int = 3, b: (Int, String) = (1, "")) = 1
  def test6(x: Int = 3, b: (Int, String) = (1, ""))(implicit z: (Int, Boolean)) = 1
  def sum[A](xs: List[A])(implicit m: List[A] ) = m
  def default1(dateStr: String = "a", b: (Int, Int))(implicit x: Int) = { List("") }

  def default(
    dateStr: String = "a", b: (Int, Int)
  )(implicit x: Int) = AuthenticatedAction { request =>
```