### PR TITLE
Fix insert import in files without a package

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -558,6 +558,7 @@ JAVA-SCALA-NEW-IMPORT is a function to format the import statement for either ja
 QUALIFIED-NAME is the name to import.
 Returns a function/closure to invoke the necessary buffer operations to perform the insertion."
   (lambda ()
+    (goto-char (point-at-eol))
     (if (equal (point) (point-max)) (newline) (forward-char 1))
     (ensime-past-starting-point starting-point)
     (save-excursion (insert (funcall java-scala-new-import qualified-name)))

--- a/features/scala-insert-import.feature
+++ b/features/scala-insert-import.feature
@@ -132,6 +132,32 @@ Feature: Insert Scala Import
     }
     """
 
+  Scenario: Insert in File without package
+    When I open temp scala file "test"
+    And I insert:
+    """
+    import scala.concurrent.duration._
+    class A(value:String){
+      def hello(){
+        new ListBuffer()
+      }
+    }
+    """
+
+    And I go to line "4"
+    And I go to end of line
+    And I insert import "org.scala.collections.mutable.ListBuffer"
+
+    Then I should see:
+    """
+    import scala.concurrent.duration._
+    import org.scala.collections.mutable.ListBuffer
+    class A(value:String){
+      def hello(){
+        new ListBuffer()
+      }
+    }
+    """
   Scenario: Insert Import Groups Import Under The Same Package Even When Already Grouped
     When I open temp scala file "test"
     And I insert:


### PR DESCRIPTION
Inserting an import in a file without a package resulted in a broken
import list. See #393