### PR TITLE
Compile tests too

### DIFF
--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -51,7 +51,7 @@
 
 (defun ensime-sbt-do-compile ()
   (interactive)
-  (sbt-command "compile"))
+  (sbt-command "test:compile"))
 
 (defun ensime-sbt-do-run ()
   (interactive)


### PR DESCRIPTION
I've changed `compile` to `test:compile` to make SBT compile the tests as well.  I'm not sure whether that has any unintended side-effects or whether it's even a good idea in general, so I'm opening this PR to "fish for feedback" :sunglasses: