### PR TITLE
ensime-search: RET key and Highlighting. (#385)

### DIFF
--- a/ensime-search.el
+++ b/ensime-search.el
@@ -79,7 +79,7 @@
     (define-key map (kbd "<down>") 'ensime-search-next-match)
     (define-key map "\C-n" 'ensime-search-next-match)
     (define-key map "\C-i" 'ensime-search-insert-import-of-current-result)
-    (define-key map [(return)] 'ensime-search-choose-current-result)
+    (define-key map (kbd "RET") 'ensime-search-choose-current-result)
     map)
   "Keymap used by ensime-search.")
 
@@ -91,7 +91,7 @@
     (define-key map "\C-n" 'ensime-search-next-match)
     (define-key map (kbd "<down>") 'ensime-search-next-match)
     (define-key map "\C-i" 'ensime-search-insert-import-of-current-result)
-    (define-key map [(return)] 'ensime-search-choose-current-result)
+    (define-key map (kbd "RET") 'ensime-search-choose-current-result)
     map)
   "Keymap used by ensime-search.")
 
@@ -285,7 +285,7 @@
 	(goto-char target-point)
 	(setq ensime-search-selection-overlay
 	      (ensime-make-overlay target-point (point-at-eol)
-				   nil 'ensime-warnline-highlight))
+				   nil '(:face 'ensime-warnline-highlight)))
 	(set-window-point (ensime-window-showing-buffer
 			   ensime-search-target-buffer)
 			  target-point)


### PR DESCRIPTION
Hi,

This pull request fixes two little bugs in the ensime-search module:

1. The RET key works now when emacs is used in a terminal. "RET" and <return> behave differently when used in a terminal or in a GUI. The fallback for <return> is alway "RET", but "RET" does not fallback to <return> which was not mapped and thus ignored.

2. The highlighting did not work correctly, because the function (ensime-make-overlay) was not used correctly.

Hope this helps a bit. Thanks for this fantastic module!

CU
Roll