### PR TITLE
Added gutter icons for compile errors and warnings in terminal mode

### DIFF
--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -255,6 +255,9 @@
         (add-hook 'after-change-functions
                   'ensime-after-change-function nil t)
 
+        (add-hook 'window-configuration-change-hook
+                  'ensime-show-left-margin-hook)
+
         (ensime-idle-typecheck-set-timer)
 
         (when ensime-tooltip-hints
@@ -288,11 +291,14 @@
       (remove-hook 'ensime-source-buffer-loaded-hook
                    'ensime-sem-high-refresh-hook)
 
-     (remove-hook 'ensime-source-buffer-loaded-hook
+      (remove-hook 'ensime-source-buffer-loaded-hook
                    'ensime-typecheck-current-buffer)
 
       (remove-hook 'after-change-functions
                    'ensime-after-change-function t)
+
+      (remove-hook 'window-configuration-change-hook
+                   'ensime-show-left-margin-hook)
 
       (remove-hook 'tooltip-functions 'ensime-tooltip-handler)
       (make-local-variable 'track-mouse)

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -237,6 +237,14 @@ and parameters."
   :type 'boolean
   :group 'ensime-ui)
 
+(defcustom ensime-left-margin-gutter t
+  "If non-nil, Ensime will show the compilation and warning icons
+in the left margin, when in terminal mode. These icons can
+interfere with other modes that use the left-margin. (git-gutter,
+linum, etc..)"
+  :type 'boolean
+  :group 'ensime-ui)
+
 (defcustom ensime-refactor-preview nil
   "Enable or disable a refactor preview feature.
 Non-nil means Ensime will show a preview of the changes in the


### PR DESCRIPTION
Hi,

I like the icons that show the errors and warnings in the fringe. As I work a lot in terminal mode, it was annoying that these icons did not work, because there is no fringe in terminal mode.

So I made some changes to show the icons in the left margin.

By default, the icons are now shown, but they can be switched of, because the left-margin is also used by git-gutter or linum and they could conflict with these modes. 

What do you think?
Is it worth integrating?

Anyway, I think it should not interfere with the 'normal' window-system mode ;-)

Roll