### PR TITLE
[discussion needed] Fix hanging import type at point when type does not exist

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -694,7 +694,7 @@ Decide what line to insert QUALIFIED-NAME."
 	 (name-start (plist-get sym :start))
 	 (name-end (plist-get sym :end))
 	 (suggestions (when name (ensime-rpc-import-suggestions-at-point (list name) 10))))
-    (when suggestions
+    (when (car-safe suggestions)
       (let* ((names (mapcar
 		     (lambda (s)
 		       (propertize (plist-get s :name)


### PR DESCRIPTION
When I have a typo and try to import a type at point, emacs freezes and I have to `<C-g>` out.

Local debugging showed that the `suggestions` are a list with `nil` in it (`(nil)`).
So the `when` check doesn't work.


I am an elisp noob, so I am not sure that this is the correct fix. In scala I would not create a `List` or `Seq` with `null` in it, so perhaps this is the underlying problem that actually needs to be addressed?

I'm also unsure how to test this. I'd like to have a feature entry that sets the cursor on a word and then calls the related function. But I'd have to assert that the autocomplete list is not shown (nothing should happens and emacs should not hang), and I don't know how to do that. Happy to hear out any suggestions or pointers.