### PR TITLE
Replace `sbt gen-ensime` with `sbt ensimeConfig`

### DIFF
--- a/ensime-config.el
+++ b/ensime-config.el
@@ -195,8 +195,8 @@ corresponding to the current buffer, followed by the sbt task
 needed to regenerate that config file. (Doesn't understand nested
 project directories, because neither does ensime-sbt.)"
   (if (equal (expand-file-name "project/" project-root) default-directory)
-      (cons (ensime-default-config-file) "gen-ensime-project")
-    (cons (ensime-default-config-file project-root) "gen-ensime")))
+      (cons (ensime-default-config-file) "ensimeConfigProject")
+    (cons (ensime-default-config-file project-root) "ensimeConfig")))
 
 (defun ensime--maybe-refresh-config (force after-refresh-fn no-refresh-fn)
   (let ((no-refresh-reason "couldn't detect project type"))

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -60,7 +60,7 @@
       (define-key prefix-map (kbd "C-b S") 'ensime-stacktrace-switch)
       (define-key prefix-map (kbd "C-b c") 'ensime-sbt-do-compile)
       (define-key prefix-map (kbd "C-b n") 'ensime-sbt-do-clean)
-      (define-key prefix-map (kbd "C-b E") 'ensime-sbt-do-gen-ensime)
+      (define-key prefix-map (kbd "C-b E") 'ensime-sbt-do-ensime-config)
       (define-key prefix-map (kbd "C-b o") 'ensime-sbt-do-test-only-dwim)
       (define-key prefix-map (kbd "C-b p") 'ensime-sbt-do-package)
       (define-key prefix-map (kbd "C-b r") 'ensime-sbt-do-run)

--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -61,9 +61,9 @@
   (interactive)
   (sbt-command "clean"))
 
-(defun ensime-sbt-do-gen-ensime ()
+(defun ensime-sbt-do-ensime-config ()
   (interactive)
-  (sbt-command "gen-ensime"))
+  (sbt-command "ensimeConfig"))
 
 (defun ensime-sbt-do-package ()
   (interactive)


### PR DESCRIPTION
`gen-ensime` produces an SBT error now, so `ensimeConfig` and `ensimeConfigProject` replace previous usage of `gen-ensime` and `gen-ensime-project`.

This fixes #443. I couldn't find a test to update. I'd be happy to add one but I'll need a hand with my rudimentary emacs lisp skills!