### PR TITLE
Added M-x ensime-troubleshooting

### DIFF
--- a/ensime-inspector.el
+++ b/ensime-inspector.el
@@ -37,7 +37,7 @@
   "Type and package inspector key bindings.")
 
 (defalias 'ensime-print-type-at-point 'ensime-type-at-point)
-(defun ensime-type-at-point (&optional arg &optional use-full-name)
+(defun ensime-type-at-point (&optional arg use-full-name)
   "Echo the type at point to the minibuffer.
 A prefix argument will add the type to the kill ring.
 If additional parameter use-full-name is provided it'll use type fullname"

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -214,6 +214,7 @@
     ["Go to stacktrace buffer" ensime-stacktrace-switch]
     ["Go to Scala REPL" ensime-inf-switch]
     ["Shutdown ENSIME server" ensime-shutdown]
+    ["Troubleshooting" ensime-troubleshooting]
     ))
 
 (define-minor-mode ensime-mode
@@ -461,6 +462,50 @@
 		 (t (format "%s" pending)))))))
 
 (provide 'ensime-mode)
+
+
+
+;;;;;; Troubleshooting
+
+
+(defun ensime-troubleshooting ()
+  "Information about emacs and ensime installation."
+  (interactive)
+  (let ((info (format
+               (concat "\n### READ THIS\n"
+                       "Have you read all the documentation at [Ensime Emacs](http://ensime.org/editors/emacs/)? Please do, we put a lot of effort into it.\n"
+                       "Most problems can be resolved easily by following a simple process, follow through our\n"
+                       "[Troubleshooting guide](http://ensime.org/editors/emacs/troubleshooting/) and share the debugging information below as a gist if you need to escalate.\n"
+                       "Do not paste this directly into the gitter chat room as it is very verbose.\n"
+                       "*****************\n"
+                       "\n## System Information - Ensime troubleshoot report\n\n"
+                       "- OS: `%s`\n"
+                       "- Emacs: `%s`\n"
+                       "- ensime-sbt-command: `%s`\n"
+                       "- debug-on-error: `%s`\n"
+                       "- exec-path: `%s`\n"
+                       "- Backtrace:\n```\n%s\n```\n"
+                       "- .ensime file content:\n```\n%s\n```\n")
+               system-type
+               emacs-version
+               (bound-and-true-p ensime-sbt-command)
+               (bound-and-true-p debug-on-error)
+               exec-path
+               (if (get-buffer "*Backtrace*")
+                   (with-current-buffer "*Backtrace*"
+                     (buffer-substring-no-properties
+                      (point-min) (min (point-max) 1000)))
+                 "Backtrace not available or not found")
+               (if (y-or-n-p "Do you want to include .ensime file content? (if yes please choose .ensime file)")
+                   (progn
+                     (let ((filePath (read-file-name "Enter .ensime file path:")))
+                       (with-temp-buffer
+                         (insert-file-contents filePath)
+                         (buffer-string))))
+                 (progn "Not provided")))))
+    (with-output-to-temp-buffer "*ensime-troubleshooting*"
+      (switch-to-buffer "*ensime-troubleshooting*")
+      (insert info))))
 
 ;; Local Variables:
 ;; End:


### PR DESCRIPTION
Removed duplicated optional in https://github.com/ensime/ensime-emacs/pull/457

Fixes https://github.com/ensime/ensime-emacs/issues/364

- I'd like to know what's the best place to put the function? (currently it's in ensime-mode.el)
- Also is not adding the report content by default to the kill-ring, only if universal argument is provided.
Should be the contrary? added by default to kill-ring and if universal argument is provided just print the content to *messages* buffer?
- Can you try if keymap combination is working?

## Example generated report

### READ THIS
Have you read all the documentation at [Ensime Emacs](http://ensime.org/editors/emacs/)? Please do, we put a lot of effort into it.
Most problems can be resolved easily by following a simple process, follow through our
[Troubleshooting guide](http://ensime.org/editors/emacs/troubleshooting/) and share the debugging information below as a gist if you need to escalate.
Do not paste this directly into the gitter chat room as it is very verbose.
*****************

## System Information - Ensime troubleshoot report

- OS: `darwin`
- Emacs: `24.5.1`
- ensime-sbt-command: `nil`
- debug-on-error: `nil`
- exec-path: `(/Users/d1egoaz/.rbenv/shims/ ~/bin/ /Users/d1egoaz/.rbenv/bin/ /usr/local/bin/ /usr/local/bin/ /usr/bin/ /bin/ /usr/sbin/ /sbin/ /opt/X11/bin/ /Users/d1egoaz/.rbenv/shims/ ~/bin/ /Users/d1egoaz/.rbenv/bin/ /usr/local/git/bin/ /usr/local/sbin/ /Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/bin/ /Users/d1egoaz/.rbenv/shims/ /usr/bin/ /bin/ /usr/sbin/ /sbin/ /usr/local/bin/ /usr/local/git/bin/ /usr/local/sbin/ /Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/bin/ /usr/local/Cellar/emacs-plus/24.5/libexec/emacs/24.5/x86_64-apple-darwin14.4.0/)`
- Backtrace:
```
Debugger entered--Lisp error: (quit)
  (while t (setq n (+ n 1)))
  (let ((n 0)) (while t (setq n (+ n 1))))
  eval-region(18252 18299)  ; Reading at buffer position 18299
  call-interactively(eval-region nil nil)
  command-execute(eval-region)

```
- .ensime file content:
```
(
 :root-dir "/Users/d1egoaz/dev/scala/akkainfo/hakky-hour"
 :cache-dir "/Users/d1egoaz/dev/scala/akkainfo/hakky-hour/.ensime_cache"
 :scala-compiler-jars ("/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.2.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.11.2.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.11.2.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scalap/jars/scalap-2.11.2.jar")
 :name "hakkyHour"
 :java-home "/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home"
 :java-flags ("-Xss2m" "-Xms1024m" "-Xmx1024m" "-XX:ReservedCodeCacheSize=128m" "-XX:MaxMetaspaceSize=256m" "-Dfile.encoding=UTF8")
 :java-compiler-args nil
 :reference-source-roots ("/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/src.zip")
 :scala-version "2.11.2"
 :compiler-args ("-unchecked" "-deprecation" "-language:_" "-target:jvm-1.6" "-encoding" "UTF-8" "-feature" "-Xlint" "-Yinline-warnings" "-Yno-adapted-args" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ywarn-unused-import" "-Ymacro-expand:discard")
 :formatting-prefs nil
 :disable-source-monitoring nil
 :disable-class-monitoring nil
 :subprojects ((
   :name "hakkyHour"
   :source-roots ("/Users/d1egoaz/dev/scala/akkainfo/hakky-hour/src/test/extra" "/Users/d1egoaz/dev/scala/akkainfo/hakky-hour/src/main/scala" "/Users/d1egoaz/dev/scala/akkainfo/hakky-hour/src/test/scala")
   :targets ("/Users/d1egoaz/dev/scala/akkainfo/hakky-hour/target/scala-2.11/classes")
   :test-targets ("/Users/d1egoaz/dev/scala/akkainfo/hakky-hour/target/scala-2.11/test-classes")
   :depends-on-modules nil
   :compile-deps ("/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-actor_2.11/jars/akka-actor_2.11-2.3.6.jar" "/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-slf4j_2.11/jars/akka-slf4j_2.11-2.3.6.jar" "/Users/d1egoaz/.ivy2/cache/com.typesafe/config/bundles/config-1.2.1.jar" "/Users/d1egoaz/.ivy2/cache/ch.qos.logback/logback-classic/jars/logback-classic-1.1.2.jar" "/Users/d1egoaz/.ivy2/cache/ch.qos.logback/logback-core/jars/logback-core-1.1.2.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.11.2.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.11/bundles/scala-parser-combinators_2.11-1.0.2.jar" "/Users/d1egoaz/.ivy2/cache/org.slf4j/slf4j-api/jars/slf4j-api-1.7.6.jar")
   :runtime-deps nil
   :test-deps ("/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-testkit_2.11/jars/akka-testkit_2.11-2.3.6.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.11.2.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/bundles/scala-xml_2.11-1.0.2.jar" "/Users/d1egoaz/.ivy2/cache/org.scalatest/scalatest_2.11/bundles/scalatest_2.11-2.2.2.jar")
   :doc-jars ("/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-actor_2.11/docs/akka-actor_2.11-2.3.6-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-slf4j_2.11/docs/akka-slf4j_2.11-2.3.6-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-testkit_2.11/docs/akka-testkit_2.11-2.3.6-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/com.typesafe/config/docs/config-1.2.1-javadoc.jar" "/Users/d1egoaz/dev/scala/akkainfo/hakky-hour/target/scala-2.11/hakky-hour_2.11-4.0.0-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/ch.qos.logback/logback-classic/docs/logback-classic-1.1.2-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/ch.qos.logback/logback-core/docs/logback-core-1.1.2-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-library/docs/scala-library-2.11.2-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.11/docs/scala-parser-combinators_2.11-1.0.2-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-reflect/docs/scala-reflect-2.11.2-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/docs/scala-xml_2.11-1.0.2-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/org.scalatest/scalatest_2.11/docs/scalatest_2.11-2.2.2-javadoc.jar" "/Users/d1egoaz/.ivy2/cache/org.slf4j/slf4j-api/docs/slf4j-api-1.7.6-javadoc.jar")
   :reference-source-roots ("/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-actor_2.11/srcs/akka-actor_2.11-2.3.6-sources.jar" "/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-slf4j_2.11/srcs/akka-slf4j_2.11-2.3.6-sources.jar" "/Users/d1egoaz/.ivy2/cache/com.typesafe.akka/akka-testkit_2.11/srcs/akka-testkit_2.11-2.3.6-sources.jar" "/Users/d1egoaz/.ivy2/cache/com.typesafe/config/srcs/config-1.2.1-sources.jar" "/Users/d1egoaz/.ivy2/cache/ch.qos.logback/logback-classic/srcs/logback-classic-1.1.2-sources.jar" "/Users/d1egoaz/.ivy2/cache/ch.qos.logback/logback-core/srcs/logback-core-1.1.2-sources.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-library/srcs/scala-library-2.11.2-sources.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.11/srcs/scala-parser-combinators_2.11-1.0.2-sources.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang/scala-reflect/srcs/scala-reflect-2.11.2-sources.jar" "/Users/d1egoaz/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/srcs/scala-xml_2.11-1.0.2-sources.jar" "/Users/d1egoaz/.ivy2/cache/org.scalatest/scalatest_2.11/srcs/scalatest_2.11-2.2.2-sources.jar" "/Users/d1egoaz/.ivy2/cache/org.slf4j/slf4j-api/srcs/slf4j-api-1.7.6-sources.jar")))
)

```