### PR TITLE
Fixes bug where to-insert was void.

### DIFF
--- a/ensime-completion-util.el
+++ b/ensime-completion-util.el
@@ -64,14 +64,13 @@
  being passed through the innards of auto-complete or company."
   (mapcar
    (lambda (completion)
-     (ensime-plist-bind
-      (type-info to-insert name)
-      completion
-      (propertize name
-                  'type-info type-info
-                  'to-insert to-insert)))
-   completions))
-
+     (let* ((name (plist-get completion :name))
+            (type-info (plist-get completion :type-info))
+            (to-insert (plist-get completion :to-insert)))
+       (propertize name
+                   'type-info type-info
+                   'to-insert to-insert
+                   ))) completions))
 
 (defun ensime-completion-prefix-at-point ()
   "Returns the prefix to complete."


### PR DESCRIPTION
Fixes bug where to-insert was void in `ensime--annotate-completions`. This was done by switching back to using `let` from `ensime-plist-bind`, as suggested by @fommil. I'm pretty new to lisp, so please let me know if there are any changes that you would like; I would be happy to make them!

Should resolve ensime/ensime-emacs#458 (at least it seems to have fixed the issue for me on my previously buggy install of ensime).