### PR TITLE
Remove special casing for by-name parameters

### DIFF
--- a/ensime-company.el
+++ b/ensime-company.el
@@ -54,23 +54,22 @@ block notation for the final parameter."
              (let* ((type-info (cadar params))
                     (block-params (plist-get (car (plist-get type-info :param-sections)) :params))
                     (result-type (plist-get type-info :result-type)))
-               (if (ensime-type-is-by-name-p type-info) " { $0 }"
-                 (concat
-                  " { "
-                  (let ((param-list
-                         (mapconcat
-                          (lambda (name-and-type)
-                            (cl-destructuring-bind (name type) name-and-type
-                              (let ((param-name (ensime--yasnippet-escape name))
-                                    (type-name (ensime--yasnippet-escape (plist-get type :name))))
-                                (format "${%s:%s: %s}" (incf tab-stop) param-name type-name))))
-                          block-params
-                          ", ")))
-                    (if (> (length block-params) 1)
-                        (format "(%s)" param-list) param-list))
-                  (let ((result-type-name (ensime--yasnippet-escape
-                                           (plist-get result-type :name))))
-                    (format " => ${%s:%s} }$0" (incf tab-stop) result-type-name)))))
+               (concat
+                " { "
+                (let ((param-list
+                       (mapconcat
+                        (lambda (name-and-type)
+                          (cl-destructuring-bind (name type) name-and-type
+                            (let ((param-name (ensime--yasnippet-escape name))
+                                  (type-name (ensime--yasnippet-escape (plist-get type :name))))
+                              (format "${%s:%s: %s}" (incf tab-stop) param-name type-name))))
+                        block-params
+                        ", ")))
+                  (if (> (length block-params) 1)
+                      (format "(%s)" param-list) param-list))
+                (let ((result-type-name (ensime--yasnippet-escape
+                                         (plist-get result-type :name))))
+                  (format " => ${%s:%s} }$0" (incf tab-stop) result-type-name))))
 
            ;; Otherwise build template for a standard parameter list.
            (concat (if infix " " "(")

--- a/ensime-model.el
+++ b/ensime-model.el
@@ -70,11 +70,6 @@
 (defun ensime-type-name-with-args (type)
   (plist-get type :name))
 
-(defun ensime-type-is-by-name-p (type)
-  ;; this should be redundant... the server should report these as arrow types
-  ;; https://github.com/ensime/ensime-server/issues/1477
-  (string-match "^scala.<byname>" (plist-get type :full-name)))
-
 (defun ensime-declared-as (obj)
   (plist-get obj :decl-as))
 
@@ -105,9 +100,7 @@
   (let* ((params (plist-get section :params))
          (arg-type (cadar params)))
     (and (= 1 (length params))
-         (or
-          (plist-get arg-type :arrow-type)
-          (ensime-type-is-by-name-p arg-type)))))
+         (plist-get arg-type :arrow-type))))
 
 (defun ensime-type-result-type (type)
   (plist-get type :result-type))


### PR DESCRIPTION
This functionality has been made redundant by fixing ensime/ensime-server#1477.