### PR TITLE
Support new by-name parameter representation in ensime-server

### DIFF
--- a/ensime-company.el
+++ b/ensime-company.el
@@ -66,8 +66,9 @@ block notation for the final parameter."
                                 (format "${%s:%s: %s}" (incf tab-stop) param-name type-name))))
                           block-params
                           ", ")))
-                    (if (> (length block-params) 1)
-                        (format "(%s)" param-list) param-list))
+                    (cond ((> (length block-params) 1) (format "(%s)" param-list)) ;; (Int, String) => ...
+                          ((= (length block-params) 1) param-list) ;; Int => ...
+                          ((= (length block-params) 0) "()"))) ;; () => ...
                   (let ((result-type-name (ensime--yasnippet-escape
                                            (plist-get result-type :name))))
                     (format " => ${%s:%s} }$0" (incf tab-stop) result-type-name)))))

--- a/ensime-model.el
+++ b/ensime-model.el
@@ -71,9 +71,9 @@
   (plist-get type :name))
 
 (defun ensime-type-is-by-name-p (type)
-  ;; this should be redundant... the server should report these as arrow types
-  ;; https://github.com/ensime/ensime-server/issues/1477
-  (string-match "^scala.<byname>" (plist-get type :full-name)))
+  ;; These two patterns should match both the old representation of by-name parameters
+  ;; from ensime and the new (standard) representation
+  (string-match "\\(^scala.<byname>\\|^=>\s+\\)" (plist-get type :full-name)))
 
 (defun ensime-declared-as (obj)
   (plist-get obj :decl-as))


### PR DESCRIPTION
This changeset includes:
- regex adjustment for by-name parameter recognition
- a completion template adjustment for function arguments with zero parameters (e.g. `() => String`).
  The block templates that were generated prior would not include the `()` part which would
  cause them to not compile.