### PR TITLE
Add autoload cookie for ensime-mode

### DIFF
--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -217,6 +217,7 @@
     ["Troubleshooting" ensime-troubleshooting]
     ))
 
+;;;###autoload
 (define-minor-mode ensime-mode
   "ENSIME: The ENhanced Scala Interaction Mode for Emacs (minor-mode).
 \\{ensime-mode-map}"


### PR DESCRIPTION
Add a single autoload cookie.

This should mean that installation instructions could be simplfied to:

    (use-package ensime
       :config (add-hook 'scala-mode 'ensime-mode))


Or 

    (use-package ensime
       :ensure t
       :config (add-hook 'scala-mode 'ensime-mode))

and use-package will install it also. Perhaps even better, put the `add-hook' form into ensime-mode, then autoload that. Then installation instructions would be "M-x package-install ensime". I can add this also.

