### PR TITLE
Add hook into scala mode

### DIFF
--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -310,6 +310,10 @@
       (when (equal major-mode 'scala-mode)
 	(ensime--unset-imenu)))))
 
+;;;###autoload
+(add-hook 'scala-mode-hook
+          'ensime-mode)
+
 ;;;;;; Mouse handlers
 
 (defun ensime-control-mouse-1-single-click (event)


### PR DESCRIPTION
Should have added this to last -- apologies.

This should automatically add the scala-mode-hook during package initialisation. This should shrink the installation instructions to a minimum.