### PR TITLE
Wrap read-char-choice in save-excursion

### DIFF
--- a/ensime-company.el
+++ b/ensime-company.el
@@ -223,7 +223,7 @@ been inserted immediately prior to the point."
                    (equal
                     ?\{
                     (or force-block
-                        (read-char-choice "{ or (" '(?\{ ?\())))))
+                        (save-excursion (read-char-choice "{ or (" '(?\{ ?\()))))))
              (snippet
               (ensime--build-yasnippet-for-call
                param-sections


### PR DESCRIPTION
Fixes #486.

The call to read-char-choice to prompt for { or ( causes point to be moved back to the last position the user typed a character rather than after the text that auto-completion just wrote to the buffer. The result is that method parameters get insert inside the auto-completed method name.
