### PR TITLE
-XX:MaxDirectMemory size for 2.0-graph build support

### DIFF
--- a/ensime-test.el
+++ b/ensime-test.el
@@ -110,7 +110,7 @@
 			      :name "test"
 			      :scala-version ,ensime--test-scala-version
 			      :java-home ,(getenv "JAVA_HOME")
-			      :java-flags ("-Xmx1g" "-Xss2m" "-XX:MaxPermSize=128m")
+			      :java-flags ("-Xmx1g" "-Xss2m" "-XX:MaxPermSize=128m" "-XX:MaxDirectMemorySize=512g")
 			      :subprojects ((:name ,sp-name
 						   :module-name ,sp-name
 						   :source-roots (,src-dir ,unit-test-dir ,int-test-dir)

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -110,7 +110,7 @@
 			      :name "test"
 			      :scala-version ,ensime--test-scala-version
 			      :java-home ,(getenv "JAVA_HOME")
-			      :java-flags ("-Xmx1g" "-Xss2m" "-XX:MaxPermSize=128m" "-XX:MaxDirectMemorySize=512g")
+			      :java-flags ("-Xmx1g" "-Xss2m" "-XX:MaxPermSize=128m" "-XX:MaxDirectMemorySize=4096mb")
 			      :subprojects ((:name ,sp-name
 						   :module-name ,sp-name
 						   :source-roots (,src-dir ,unit-test-dir ,int-test-dir)

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -110,7 +110,7 @@
 			      :name "test"
 			      :scala-version ,ensime--test-scala-version
 			      :java-home ,(getenv "JAVA_HOME")
-			      :java-flags ("-Xmx1g" "-Xss2m" "-XX:MaxPermSize=128m" "-XX:MaxDirectMemorySize=4096mb")
+			      :java-flags ,(append (getenv "ENSIME_JVM_TEST_FLAGS") '("-Xmx1g" "-Xss2m" "-XX:MaxPermSize=128m"))
 			      :subprojects ((:name ,sp-name
 						   :module-name ,sp-name
 						   :source-roots (,src-dir ,unit-test-dir ,int-test-dir)


### PR DESCRIPTION
This should make it so ensime-server 2.0-graph won't crash on emacs tests. At least this works for me locally.