### PR TITLE
Remove text properties from search input

### DIFF
--- a/ensime-search.el
+++ b/ensime-search.el
@@ -161,7 +161,7 @@
 
 
 (defun ensime-search-mode ()
-  "Major mode for incrementally seaching through all open buffers."
+  "Major mode for incrementally searching through all open buffers."
   (interactive)
   (setq major-mode 'ensime-search-mode
         mode-name "ensime-search")
@@ -310,7 +310,7 @@
  BEG, END and LENOLD are passed in from the hook.
  An actual update is only done if the regexp has changed or if the
  optional fourth argument FORCE is non-nil."
-  (let ((new-query (buffer-string)))
+  (let ((new-query (buffer-substring-no-properties (point-min) (point-max))))
     (when (not (equal new-query ensime-search-text))
       (setq ensime-search-text new-query)
       (if (>= (length new-query) ensime-search-min-length)

--- a/ensime-search.el
+++ b/ensime-search.el
@@ -150,7 +150,13 @@
      (use-local-map ensime-search-target-buffer-map)
      (setq ensime-buffer-connection conn)
 
-     (select-window (split-window (selected-window) (- (window-height) 4)))
+     ;; Compute the heights of the search window and text entry area
+     ;; The entry height is 4 lines unless the window-height is too small
+     (let* ((wh (window-height))
+            (eh (min (- wh 2) 4))
+            (size (- wh eh)))
+       (select-window (split-window (selected-window) size))
+       )
      (switch-to-buffer (get-buffer-create ensime-search-buffer-name))
      (setq ensime-buffer-connection conn)
      (erase-buffer)

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1338,37 +1338,37 @@
          (ensime-externalize-offset (ensime-test-after-label "2"))))
       (ensime-test-cleanup proj))))
 
-   ;; (ensime-async-test
-   ;;  "Test interactive search."
-   ;;  (let* ((proj (ensime-create-tmp-project
-   ;;                ensime-tmp-project-hello-world)))
-   ;;    (ensime-test-init-proj proj))
+   (ensime-async-test
+    "Test interactive search."
+    (let* ((proj (ensime-create-tmp-project
+                  ensime-tmp-project-hello-world)))
+      (ensime-test-init-proj proj))
 
-   ;;  ((:connected))
-   ;;  ((:compiler-ready :full-typecheck-finished :indexer-ready)
-   ;;   (ensime-test-with-proj
-   ;;    (proj src-files)
-   ;;    ;; Prevent a previous search from affecting this test
-   ;;    (setq ensime-search-text "")
-   ;;    (ensime-search)
-   ;;    (insert "scala.collection.immutable.Vector")))
+    ((:connected))
+    ((:compiler-ready :full-typecheck-finished :indexer-ready)
+     (ensime-test-with-proj
+      (proj src-files)
+      ;; Prevent a previous search from affecting this test
+      (setq ensime-search-text "")
+      (ensime-search)
+      (insert (propertize "scala.collection.immutable.Vector" 'face 'italic))))
 
-   ;;  ((:search-buffer-populated)
-   ;;   (ensime-test-with-proj
-   ;;    (proj src-files)
+    ((:search-buffer-populated)
+     (ensime-test-with-proj
+      (proj src-files)
 
-   ;;    (with-current-buffer ensime-search-target-buffer-name
-   ;;      ;; uncomment to see the results (e.g. if they change due to server improvements)
-   ;;      ;;(message "%s" (buffer-string))
-   ;;      (goto-char 1)
-   ;;      (ensime-assert (search-forward-regexp "scala.collection.immutable.Vector[[:space:]]+" nil t))
-   ;;      (goto-char 1)
-   ;;      ;; I don't necessarilly agree with these results, indeed they will change when
-   ;;      ;; we refactor the search backend.
-   ;;      (ensime-assert (search-forward "scala.collection.immutable.VectorIterator" nil t)))
+      (with-current-buffer ensime-search-target-buffer-name
+        ;; uncomment to see the results (e.g. if they change due to server improvements)
+        ;;(message "%s" (buffer-string))
+        (goto-char 1)
+        (ensime-assert (search-forward-regexp "scala.collection.immutable.Vector[[:space:]]+" nil t))
+        (goto-char 1)
+        ;; I don't necessarilly agree with these results, indeed they will change when
+        ;; we refactor the search backend.
+        (ensime-assert (search-forward "scala.collection.immutable.VectorIterator" nil t)))
 
-   ;;    (ensime-search-quit)
-   ;;    (ensime-test-cleanup proj))))
+      (ensime-search-quit)
+      (ensime-test-cleanup proj))))
 
 
    (ensime-async-test


### PR DESCRIPTION
Remove any text properties (these are preserved for yanked text) before submitting a search query to the server.

The fix for the issue was trivial. The real effort was making the unit test run. There was an existing "Interactive search test" in ensime-test.el that was commented out; probably because it crashed. That problem turned out to be caused by ``split-window`` failing because the search window was too small to be split into the results/entry areas. The tests run in emacs --batch mode which provides a very small frame (about 10x10) which is too small to contain all the windows.

We now gracefully reduce the size of the text entry area based on the size of the search window. I expect no one will ever run into this outside of the unit tests.

Fixes #482 
