### PR TITLE
flush blank lines when sending region to Scala interpreter

### DIFF
--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -242,6 +242,19 @@ the current project's dependencies. Returns list of form (cmd [arg]*)"
       (comint-send-string nil "\n")
       (comint-send-eof))))
 
+(defun ensime-inf-eval-result ()
+  "Get REPL evaluation result."
+  (with-current-buffer ensime-inf-buffer-name
+    (save-excursion
+      (goto-char (point-max))
+      (next-line -1)
+      (end-of-line)
+      (let ((end (point)))
+        (search-backward "Exiting paste mode, now interpreting.")
+        (next-line)
+        (beginning-of-line)
+        (buffer-substring-no-properties (point) end)))))
+
 (defun ensime-inf-eval-definition ()
   "Send the current 'definition' to the Scala interpreter.
 

--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -234,8 +234,13 @@ the current project's dependencies. Returns list of form (cmd [arg]*)"
   "Send current region to Scala interpreter."
   (interactive "r")
   (ensime-inf-assert-running)
-  (comint-send-region ensime-inf-buffer-name start end)
-  (comint-send-string ensime-inf-buffer-name "\n"))
+
+  (let ((reg (buffer-substring-no-properties start end)))
+    (with-current-buffer ensime-inf-buffer-name
+      (comint-send-string nil ":paste\n")
+      (comint-send-string nil reg)
+      (comint-send-string nil "\n")
+      (comint-send-eof))))
 
 (defun ensime-inf-eval-definition ()
   "Send the current 'definition' to the Scala interpreter.

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1832,6 +1832,45 @@
        (ensime-test-with-proj (proj src-files) (ensime-cleanup-tmp-project proj)))))
 
    (ensime-async-test
+    "Test REPL paste mode."
+    (let* ((proj (ensime-create-tmp-project
+                  `((:name
+                     "hello_world.scala"
+                     :contents ,(ensime-test-concat-lines
+                                 "sealed trait Foo"
+                                 "object Foo {"
+                                 ""
+                                 ""
+                                 ""
+                                 "}"
+                                 ""))))))
+      (ensime-test-init-proj proj))
+    ((:connected))
+    ((:compiler-ready :full-typecheck-finished)
+     (ensime-test-with-proj
+      (proj src-files)
+      (ensime-inf-run-scala)))
+    ((:inf-repl-ready)
+     (ensime-test-with-proj
+      (proj src-files)
+      (find-file (car src-files))
+      (ensime-inf-eval-region (point-min) (point-max))))
+    ((:inf-repl-ready)
+     (ensime-test-with-proj
+      (proj src-files)
+      (ensime-assert (string= (ensime-inf-eval-result)
+                              (ensime-test-concat-lines
+                               ""
+                               "defined trait Foo"
+                               "defined object Foo"
+                               "")))
+      (ensime-inf-quit-interpreter)))
+    ((:inf-repl-exit)
+     (ensime-test-with-proj
+      (proj src-files)
+      (ensime-test-cleanup proj))))
+
+   (ensime-async-test
     "Ensime unit test dwim."
     (let* ((proj (ensime-create-tmp-project
 		  `((:name


### PR DESCRIPTION
When using `ensime-inf-eval-region` to evaluate a Scala expression with multiple blank lines, the interpreter produces the following error:
````
scala>      |      | You typed two blank lines.  Starting a new command.

scala> <console>:1: error: eof expected but '}' found.
}

`````
The fix is to remove all blank lines from the region before sending it to `ensime-inf-eval-region`.
