### PR TITLE
Fix sbt-do-test-only when the cursor is inside a string

### DIFF
--- a/ensime-goto-testfile.el
+++ b/ensime-goto-testfile.el
@@ -81,10 +81,13 @@ or (if the point isn't inside a class definition) the class that follows
 the point. Return nil if no class can be found."
   ;; TODO use an RPC call instead of this cheesy search
   (cl-labels
-      ((pos-of-top-level-class (&optional last-try)
+      ((inside-string? () (nth 3 (syntax-ppss)))
+       (pos-of-top-level-class (&optional last-try)
          (save-excursion
            (save-restriction
              (widen)
+             (while (inside-string?)
+               (goto-char (1- (point))))
              (let ((top-level-sexp (point)))
                ;; Try to go up a sexp until we get an error
                (condition-case nil


### PR DESCRIPTION
Steps to reproduce:
1. Open RichPresentationCompilerSpec.scala.
2. Place the cursor on any string inside RichPresentationCompilerSpec.
3. M-x ensime-sbt-do-test-only-dwim.

It runs RichPresentationCompilerThatNeedsJavaLibsSpec instead.

The problem is in incorrect behavior of backward-up-list when the cursor is inside a string. The workaround is ensuring that backward-up-list is not called from a string.

"inside-string?" predicate was taken from here: http://ergoemacs.org/emacs/elisp_determine_cursor_inside_string_or_comment.html