### PR TITLE
option to display type and errors at point inline

### DIFF
--- a/ensime-inspector.el
+++ b/ensime-inspector.el
@@ -6,6 +6,7 @@
 
 (require 'dash)
 (require 'imenu)
+(require 'ensime-overlay)
 
 ;; Type Inspector UI
 
@@ -46,8 +47,13 @@ If additional parameter use-full-name is provided it'll use type fullname"
          (type-name (if use-full-name
                         (ensime-type-full-name-with-args type)
                       (ensime-type-name-with-args type))))
-    (when arg
+    (when  (equal arg '(4))
       (kill-new type-name))
+    (when (equal arg '(16))
+      (ensime--make-result-overlay
+          (format "%S" type-name)
+        :where (point)
+        :duration 'command))
     (message type-name)))
 
 (defun ensime-type-at-point-full-name (&optional arg)

--- a/ensime-notes.el
+++ b/ensime-notes.el
@@ -6,6 +6,7 @@
 
 (require 'dash)
 (require 'cl-lib)
+(require 'ensime-overlay)
 
 ;; Note: This might better be a connection-local variable, but
 ;; afraid that might lead to hanging overlays..
@@ -36,6 +37,7 @@
 
     (ensime-make-note-overlays notes)
     (ensime-update-note-counts)
+    (ensime-event-sig :notes-added)
     ))
 
 
@@ -271,12 +273,19 @@ any buffer visiting the given file."
 (defun ensime-errors-at (point)
   (delq nil (mapcar (lambda (x) (overlay-get x 'help-echo)) (ensime-overlays-at point))))
 
-(defun ensime-print-errors-at-point ()
-  (interactive)
+(defun ensime-print-errors-at-point (&optional arg)
+  (interactive "P")
   (let ((msgs (append (ensime-errors-at (point))
                       (ensime-implicit-notes-at (point)))))
     (when msgs
-      (message "%s" (mapconcat 'identity msgs "\n")))))
+      (let ((msg (mapconcat 'identity msgs "\n")))
+        (when (equal arg '(16))
+          (ensime--make-result-overlay
+              (format "%S" msg)
+            :where (point)
+            :duration 'command))
+        (message "%s" msg)))
+    (ensime-event-sig :errors-at-point-printed)))
 
 (defun ensime-implicit-notes-at (point)
   (cl-labels


### PR DESCRIPTION
ensime-type-at-point, ensime-type-at-point-full-name and
ensime-print-errors-at-point with "C-u C-u" prefix argument display
the result inline using the CIDER style overlay.