### PR TITLE
default ensime server version to stable 1.0.0

### DIFF
--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -70,7 +70,7 @@ works for sbt projects."
   :group 'ensime-ui)
 
 (defcustom ensime-server-version
-  (or (getenv "ENSIME_SERVER_VERSION") "2.0.0-SNAPSHOT")
+  (or (getenv "ENSIME_SERVER_VERSION") "1.0.0")
   "Distributed version of the server to upgrade and start.
 This is primarily useful for ENSIME developers (or bug reporters)
 to test against. The client is designed to work with the default


### PR DESCRIPTION
wouldn't it make more sense to default ensime-server to a stable version? as it stands, every user gets a warning about using an unstable snapshot, and then needs to either configure the stable version or make a configuration to acknowledge that they are using bleeding edge...