### PR TITLE
Remove needless argument

### DIFF
--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -141,12 +141,6 @@
   "Keymap for ENSIME mode."
   )
 
-;;;;; ensime-mode
-(defun ensime-scala-mode-hook ()
-  "Convenient hook function to start `ensime-mode'."
-  (scala-mode 1)
-  (ensime-mode 1))
-
 (defun ensime-run-after-save-hooks ()
   "Things to run whenever a source buffer is saved."
   (when (ensime-source-file-p)


### PR DESCRIPTION
major-mode functions does not take any arguments. 