### PR TITLE
cl cleanup

### DIFF
--- a/ensime-auto-complete.el
+++ b/ensime-auto-complete.el
@@ -214,6 +214,7 @@ be used later to give contextual help when entering arguments."
     (symbol . "f")
     ))
 
+;;;###autoload
 (defun ensime-ac-enable ()
   (when ensime-ac-override-settings
     (make-local-variable 'ac-sources)

--- a/ensime-client.el
+++ b/ensime-client.el
@@ -398,7 +398,7 @@ This doesn't mean it will connect right after Ensime is loaded."
 (defun ensime-generate-connection-name (server-name)
   (loop for i from 1
 	for name = server-name then (format "%s<%d>" server-name i)
-	while (find name ensime-net-processes
+	while (cl-find name ensime-net-processes
 		    :key #'ensime-connection-name :test #'equal)
 	finally (return name)))
 

--- a/ensime-comint-utils.el
+++ b/ensime-comint-utils.el
@@ -64,10 +64,10 @@ the output received after a call to `ensime-comint-complete'.")
     (let* ((output-list
             (split-string (ensime-comint-sanitise output) cand-regexp t))
            (input (car output-list))
-           (invalid-input (find err-regexp output-list :test 'string-match))
+           (invalid-input (cl-find err-regexp output-list :test 'string-match))
            (rev-output-list (reverse output-list))
            (prompt-completion
-            (find comint-prompt-regexp rev-output-list :test 'string-match))
+            (cl-find comint-prompt-regexp rev-output-list :test 'string-match))
            ;; this is very ugly
            (trailing-space (if (and (string= (replace-regexp-in-string "\s" "" input)
                                              (replace-regexp-in-string

--- a/ensime-company.el
+++ b/ensime-company.el
@@ -115,6 +115,7 @@ block notation for the final parameter."
         (indent-region (region-beginning) (region-end))
       (indent-according-to-mode))))
 
+;;;###autoload
 (defun ensime-company-enable ()
   (make-local-variable 'company-backends)
   (push #'ensime-company company-backends)

--- a/ensime-goto-testfile.el
+++ b/ensime-goto-testfile.el
@@ -53,7 +53,7 @@ implementation class. With an argument, open the test file in another window."
          (case-fold-search nil)
          (module-params
           (cdr
-           (find module-name ensime-goto-test-configs
+           (cl-find module-name ensime-goto-test-configs
                  :test (lambda (m p) (string-match-p (car p) m))))))
     (if (plist-member module-params key)
         (plist-get module-params key)
@@ -239,7 +239,7 @@ implementation class."
              (mapcar (lambda (s)
                        (file-name-as-directory (expand-file-name s)))
                      (plist-get module :source-roots))))
-        (when (find impl-dir module-sources :test #'equal)
+        (when (cl-find impl-dir module-sources :test #'equal)
           (return (find-if is-test-dir-fn module-sources)))))))
 
 (defun ensime-goto-test--is-test-dir (dir)

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -1,8 +1,9 @@
 ;;; ensime-mode.el --- ensime mode
 
 (eval-when-compile
-  (require 'cl)
   (require 'ensime-macros))
+
+(require 'cl) ;; needs to be interpreter until we catch all uses
 
 (require 'arc-mode)
 (require 'comint)
@@ -437,8 +438,8 @@
                         t))
 
        ;; Show implicit conversions if present
-       ((or (find 'implicitConversion sem-high-overlays)
-            (find 'implicitParams sem-high-overlays))
+       ((or (member 'implicitConversion sem-high-overlays)
+            (member 'implicitParams sem-high-overlays))
         (ensime-tooltip-show-message
          (mapconcat 'identity (ensime-implicit-notes-at point) "\n")))
 

--- a/ensime-popup.el
+++ b/ensime-popup.el
@@ -85,7 +85,7 @@ The buffer also uses the minor-mode `ensime-popup-buffer-mode'."
 	(set (make-local-variable 'ensime-popup-restore-data)
 	     (list new-window
 		   selected-window
-		   (cdr (find new-window old-windows :key #'car)))))
+		   (cdr (cl-find new-window old-windows :key #'car)))))
       (when select
 	(select-window new-window))
       new-window)))

--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -17,7 +17,7 @@
   "Hook called whenever a new process gets started.")
 
 (defvar ensime--classpath-separator
-  (if (find system-type '(cygwin windows-nt)) ";" ":")
+  (if (member system-type '(cygwin windows-nt)) ";" ":")
   "Separator used in Java classpaths")
 
 (defvar ensime--abort-connection nil)

--- a/ensime-ui.el
+++ b/ensime-ui.el
@@ -227,7 +227,7 @@
 	  (setq ensime-ui-nav-restore-data
 		(list new-window
 		      selected-window
-		      (cdr (find new-window
+		      (cdr (cl-find new-window
 				 old-windows
 				 :key #'car)))))
 	(when select

--- a/ensime.el
+++ b/ensime.el
@@ -22,11 +22,6 @@
 
 (require 'ensime-mode)
 
-;; autoload ensime-ac-enable and ensime-company-enable so that the
-;; user can select which backend to use without loading both.
-(autoload 'ensime-company-enable "ensime-company")
-(autoload 'ensime-ac-enable "ensime-auto-complete")
-
 (defvar ensime-protocol-version "1.0")
 
 (defvar ensime-prefer-noninteractive t

--- a/features/step-definitions/ensime-emacs-steps.el
+++ b/features/step-definitions/ensime-emacs-steps.el
@@ -2,6 +2,8 @@
 ;; files in this directory whose names end with "-steps.el" will be
 ;; loaded automatically by Ecukes.
 
+(require 'ensime-company) ;; the autoload cookie is not available in unit tests
+
 (When "^I open temp \\(java\\|scala\\) file \"\\(.+\\)\"$"
       (lambda (suffix arg)
         (find-file (make-temp-file arg nil (format ".%s" suffix)))))

--- a/test/ensime-emacs-test.el
+++ b/test/ensime-emacs-test.el
@@ -190,7 +190,7 @@
      (should (equal internalized-syms expected)))))
 
 (ert-deftest ensime-emacs-test-path-includes-dir-p ()
-    (unless (find system-type '(windows-nt cygwin))
+  (unless (member system-type '(windows-nt cygwin))
       (let ((d (make-temp-file "ensime_test_proj" t)))
         (make-directory (concat d "/proj/src/main") t)
         (make-directory (concat d "/proj/src/main/java") t)


### PR DESCRIPTION
I was getting some "missing symbol `find`" errors depending on the order of loading files after starting emacs.