### PR TITLE
Support Play's default dir layout

### DIFF
--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -163,6 +163,7 @@ again."
   (let* ((file-name (or buffer-file-name default-directory))
          (source-set (cond
                       ((string-match-p "src/test" file-name) "")
+                      ((string-match-p "/test" file-name) "") ;; for Play's default dir layout
                       ((string-match-p "src/it" file-name) "it:")
                       ((string-match-p "src/fun" file-name) "fun:"))))
     (if source-set


### PR DESCRIPTION
Play does not follow the SBT standard dir layout, it is sweet to support that though it is configurable to re-layout