### PR TITLE
Use ensimeScalariformOnly to format buffer

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -949,13 +949,6 @@ copies. All other objects are used unchanged. List must not contain cycles."
 (defun ensime-rpc-async-typecheck-all (continue)
   (ensime-eval-async `(swank:typecheck-all) continue))
 
-(defun ensime-rpc-async-format-files (file-names continue)
-  (ensime-eval-async `(swank:format-source ,file-names) continue))
-
-(defun ensime-rpc-format-buffer ()
-  (ensime-eval `(swank:format-one-source (:file ,buffer-file-name
-                                          :contents ,(ensime-get-buffer-as-string)))))
-
 (defun ensime-rpc-expand-selection (file-name start end)
   (ensime-internalize-offset-fields
    (ensime-eval `(swank:expand-selection

--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -730,21 +730,6 @@ Decide what line to insert QUALIFIED-NAME."
 	      (ensime-insert-import qual-name)
 	      (ensime-typecheck-current-buffer))))))))
 
-;; Source Formatting
-
-(defun ensime-format-source ()
-  "Format the source in the current buffer using the Scalariform
- formatting library."
-  (interactive)
-  (let ((formatted (ensime-rpc-format-buffer)))
-    (when formatted
-      (when (eq 1 (coding-system-eol-type buffer-file-coding-system))
-        (setq formatted (replace-regexp-in-string "\r$" "" formatted)))
-      (let ((pt (point)))
-        (erase-buffer)
-        (insert formatted)
-        (goto-char pt)))))
-
 (defun ensime-revert-visited-files (files &optional typecheck)
   "files is a list of buffer-file-names to revert or lists of the form
  (visited-file-name disk-file-name) where buffer visiting visited-file-name

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -66,7 +66,6 @@
       (define-key prefix-map (kbd "C-v r") 'ensime-show-uses-of-symbol-at-point)
       (define-key prefix-map (kbd "C-v s") 'ensime-sbt-switch)
       (define-key prefix-map (kbd "C-v z") 'ensime-inf-switch)
-      (define-key prefix-map (kbd "C-v f") 'ensime-format-source)
       (define-key prefix-map (kbd "C-v u") 'ensime-undo-peek)
       (define-key prefix-map (kbd "C-v v") 'ensime-search)
       (define-key prefix-map (kbd "C-v d") 'ensime-show-doc-for-symbol-at-point)
@@ -105,6 +104,7 @@
       (define-key prefix-map (kbd "C-b S") 'ensime-stacktrace-switch)
       (define-key prefix-map (kbd "C-b c") 'ensime-sbt-do-compile)
       (define-key prefix-map (kbd "C-b C") 'ensime-sbt-do-compile-only)
+      (define-key prefix-map (kbd "C-b f") 'ensime-sbt-do-scalariform-only)
       (define-key prefix-map (kbd "C-b n") 'ensime-sbt-do-clean)
       (define-key prefix-map (kbd "C-b E") 'ensime-sbt-do-ensime-config)
       (define-key prefix-map (kbd "C-b o") 'ensime-sbt-do-test-only-dwim)
@@ -186,7 +186,6 @@
     ("Test")
 
     ("Source"
-     ["Format source" ensime-format-source]
      ["Find all references" ensime-show-uses-of-symbol-at-point]
      ["Inspect type" ensime-inspect-type-at-point]
      ["Inspect type in another frame" ensime-inspect-type-at-point-other-frame]
@@ -233,6 +232,7 @@
      ["Test" ensime-sbt-do-test]
      ["Test Quick" ensime-sbt-do-test-quick]
      ["Test current class" ensime-sbt-do-test-only]
+     ["Format source" ensime-sbt-do-scalariform-only]
      ["Run" ensime-sbt-do-run]
      ["Package" ensime-sbt-do-package])
 

--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -58,10 +58,20 @@
   "Save the current buffer and compile it using `sbt-ensime's `ensimeCompileOnly' Task."
   (interactive)
   (save-buffer)
-  (let* ((subproject (ensime-subproject-for-config)))
+  (ensime-sbt-run-command-in-subproject "ensimeCompileOnly" buffer-file-name))
+
+(defun ensime-sbt-do-scalariform-only ()
+  "Format the current file using Scalariform."
+  (interactive)
+  (save-buffer)
+  (ensime-sbt-run-command-in-subproject "ensimeScalariformOnly" buffer-file-name))
+
+(defun ensime-sbt-run-command-in-subproject (command file-name)
+  "Run a sbt COMMAND in the module containing FILE-NAME, if specified."
+  (let ((subproject (ensime-subproject-for-config)))
     (if subproject
-        (sbt-command (concat subproject "/ensimeCompileOnly " buffer-file-name))
-      (sbt-command (concat "ensimeCompileOnly " buffer-file-name)))))
+        (sbt-command (concat subproject "/" command " " file-name))
+      (sbt-command (concat command " " file-name)))))
 
 (defun ensime-sbt-do-run ()
   (interactive)

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1251,15 +1251,23 @@
    ;;    (ensime-test-cleanup proj))))
 
    (ensime-async-test
-    "Test formatting source."
+    "Ensime integration test formatting source with scalariform-only"
     (let* ((proj (ensime-create-tmp-project
                   `((:name
                      "format_world.scala"
+                     :relative-to "src/main/scala"
                      :contents ,(ensime-test-concat-lines
                                  "class HelloWorld{"
                                  "def foo:Int=1"
                                  "}"
-                                 ""))))))
+                                 ""))
+                    (:name "plugins.sbt"
+                           :relative-to "project"
+                           :contents ,(ensime-test-concat-lines
+                                       (concat "addSbtPlugin\(\"org.scalariform\" \% \"sbt-scalariform\" \% \"1\.6\.0\" \)"))))
+                  ))
+           (src-files (plist-get proj :src-files)))
+      (assert ensime-sbt-command)
       (ensime-test-init-proj proj))
 
     ((:connected))
@@ -1267,7 +1275,7 @@
      (ensime-test-with-proj
       (proj src-files)
       (find-file (car src-files))
-      (ensime-format-source)
+			(tests '(("ensimeScalariformOnly" ensime-sbt-do-scalariform-only)))
       (let ((src (buffer-substring-no-properties
                   (point-min) (point-max))))
         (ensime-assert-equal src (ensime-test-concat-lines

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -1251,41 +1251,6 @@
    ;;    (ensime-test-cleanup proj))))
 
    (ensime-async-test
-    "Ensime integration test formatting source with scalariform-only"
-    (let* ((proj (ensime-create-tmp-project
-                  `((:name
-                     "format_world.scala"
-                     :relative-to "src/main/scala"
-                     :contents ,(ensime-test-concat-lines
-                                 "class HelloWorld{"
-                                 "def foo:Int=1"
-                                 "}"
-                                 ""))
-                    (:name "plugins.sbt"
-                           :relative-to "project"
-                           :contents ,(ensime-test-concat-lines
-                                       (concat "addSbtPlugin\(\"org.scalariform\" \% \"sbt-scalariform\" \% \"1\.6\.0\" \)"))))
-                  ))
-           (src-files (plist-get proj :src-files)))
-      (assert ensime-sbt-command)
-      (ensime-test-init-proj proj))
-
-    ((:connected))
-    ((:compiler-ready :full-typecheck-finished)
-     (ensime-test-with-proj
-      (proj src-files)
-      (find-file (car src-files))
-			(tests '(("ensimeScalariformOnly" ensime-sbt-do-scalariform-only)))
-      (let ((src (buffer-substring-no-properties
-                  (point-min) (point-max))))
-        (ensime-assert-equal src (ensime-test-concat-lines
-                                  "class HelloWorld {"
-                                  "  def foo: Int = 1"
-                                  "}"
-                                  "")))
-      (ensime-test-cleanup proj))))
-
-   (ensime-async-test
     "Get package info for com.helloworld."
     (let* ((proj (ensime-create-tmp-project
                   ensime-tmp-project-hello-world)))


### PR DESCRIPTION
- Add ensime-sbt-do-scalariform-only functions
- Refactor common code with ensime-sbt-do-compile-only