### PR TITLE
Revert "Revert "Set ensime-inf-overlay-marker in sbt buffers""

### DIFF
--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -36,6 +36,7 @@
    conn
    (with-current-buffer (sbt-start)
      (setq ensime-buffer-connection conn)
+     (setq ensime-inf-overlay-marker nil)
      (add-hook 'ensime-source-buffer-saved-hook 'ensime-sbt-maybe-auto-compile)
      (add-hook 'comint-output-filter-functions 'ensime-inf-postoutput-filter))))
 


### PR DESCRIPTION
Reverts ensime/ensime-emacs#528

which is reverting the revert. I can reproduce locally according to https://github.com/ensime/ensime-emacs/issues/526 (but I need to open a .scala file in between).

I don't really consider this issue closed properly, this feels like a workaround... it would be much better to work out why it is happening. @greenrd 