### PR TITLE
Create ensime-inf-overlay-marker variable correctly

### DIFF
--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -81,6 +81,8 @@ with data loaded from server."
 Caches the last pair used in the last ensime-inf-load-file.
 Used for determining the default in the next one.")
 
+(defvar ensime-inf-overlay-marker nil)
+
 
 (define-derived-mode ensime-inf-mode comint-mode "Scala REPL"
   "Major mode for interacting with a Scala interpreter."
@@ -95,7 +97,6 @@ Used for determining the default in the next one.")
        '(ansi-color-process-output
          comint-postoutput-scroll-to-bottom
          ensime-inf-postoutput-filter))
-  (setq ensime-inf-overlay-marker nil)
 
   (if ensime-inf-ansi-support
       (set (make-local-variable 'ansi-color-for-comint-mode) t)

--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -17,6 +17,7 @@
 
 (require 'sbt-mode)
 (require 'ensime-config)
+(require 'ensime-inf)
 
 (defgroup ensime-sbt nil
   "Support for sbt build REPL."
@@ -36,7 +37,6 @@
    conn
    (with-current-buffer (sbt-start)
      (setq ensime-buffer-connection conn)
-     (setq ensime-inf-overlay-marker nil)
      (add-hook 'ensime-source-buffer-saved-hook 'ensime-sbt-maybe-auto-compile)
      (add-hook 'comint-output-filter-functions 'ensime-inf-postoutput-filter))))
 


### PR DESCRIPTION
This ensures it will only be set to nil if not already set.

Fixes #526 in the correct way.