### PR TITLE
Make sbt tasks work with test files

### DIFF
--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -71,8 +71,12 @@
   "Run a sbt COMMAND in the module containing FILE-NAME, if specified."
   (let ((subproject (ensime-subproject-for-config)))
     (if subproject
-        (sbt-command (concat subproject "/" command " " file-name))
-      (sbt-command (concat command " " file-name)))))
+        (if (ensime-is-test-file file-name)
+            (sbt-command (concat subproject "/" "test:" command " " file-name))
+          (sbt-command (concat subproject "/" command " " file-name)))
+      (if (ensime-is-test-file file-name)
+          (sbt-command (concat "test:"command " " file-name))
+        (sbt-command (concat command " " file-name))))))
 
 (defun ensime-sbt-do-run ()
   (interactive)

--- a/ensime-test.el
+++ b/ensime-test.el
@@ -2062,48 +2062,7 @@
 	  (apply f)
 	  (ensime-assert-equal (sbt:get-previous-command) command)))
       (ensime-test-cleanup proj))))
-
-   (ensime-async-test
-    "Ensime integration test compile-only."
-    (let* ((proj (ensime-create-tmp-project
-                  `((:name
-                     "apackage/Example.scala"
-                     :relative-to "src/main/scala"
-                     :contents ,(ensime-test-concat-lines
-                                 "package apackage"
-                                 "object Example {"
-                                 "  def foo = println(\"foo\")"
-                                 "}"))
-                    (:name "build.sbt"
-                           :relative-to ""
-                           :contents ,(ensime-test-concat-lines
-                                       (concat "scalaVersion := \"" ensime--test-scala-version "\"")
-                                       (concat "scalaBinaryVersion := \"" (ensime--scala-binary-version ensime--test-scala-version) "\"")
-                                       ""
-                                       "lazy val root ="
-                                       "  Project(\"root\", file(\".\"))"
-                                       )))
-                  nil "root" '("src/main/scala")))
-           (src-files (plist-get proj :src-files)))
-      (assert ensime-sbt-command)
-      (ensime-test-init-proj proj))
-
-    ((:connected))
-    ((:compiler-ready :full-typecheck-finished :indexer-ready)
-     (ensime-test-with-proj
-      (proj src-files)
-      (dolist
-          (tests '(("ensimeCompileOnly" ensime-sbt-do-compile-only)
-                   ))
-        (let* ((module (-> (plist-get proj :config)
-                           (plist-get :subprojects)
-                           -first-item
-                           (plist-get :name)))
-               (command (s-concat module "/" (car tests) " " buffer-file-name))
-               (f (cdr tests)))
-          (apply f)
-          (ensime-assert-equal (sbt:get-previous-command) command)))
-      (ensime-test-cleanup proj))))))
+   ))
 
 (defun ensime-run-all-tests ()
   "Run all regression tests for ensime-mode."


### PR DESCRIPTION
Simple but not so elegant fix to make `ensimeCompileOnly` and `ensimeScalariformOnly` work with files in test folders

Close #539 