### PR TITLE
bump timeout before cleanup to 3 seconds

### DIFF
--- a/ensime-test.el
+++ b/ensime-test.el
@@ -533,7 +533,7 @@
       (message "OK no unreplied messages")))
   (ensime-kill-all-ensime-servers)
 					; In Windows, we can't delete cache files until the server process has exited
-  (sleep-for 1)
+  (sleep-for 3)
   (ensime-cleanup-tmp-project proj no-del))
 
 ;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
I've not been able to trace problems with `2.0-graph` emacs tests all the way to the real cause, but this seems to fix it for me locally. Probably has something to do with orient not closing in time.