### PR TITLE
ensure default-directory ends with slash

### DIFF
--- a/ensime-config.el
+++ b/ensime-config.el
@@ -218,7 +218,7 @@ project directories, because neither does ensime-sbt.)"
 (defun ensime--refresh-config-sbt (project-root task on-success-fn)
   (with-current-buffer (get-buffer-create "*ensime-gen-config*")
     (erase-buffer)
-      (let ((default-directory project-root))
+      (let ((default-directory (file-name-as-directory project-root)))
         (if (executable-find ensime-sbt-command)
             (let ((process (start-process "*ensime-gen-config*" (current-buffer)
                                           ensime-sbt-command task)))


### PR DESCRIPTION
Hello,
generating the ensime config file via the `ensime-refresh-config` (from lisp, not interactively) didn't work for me. It created the config file in the wrong folder (not in the project directory but one above). I then found that the `default-directory` used for the sbt process didn't end in a slash, and changing that fixed my problem. But it works when calling it interactively from within a scala buffer that is connected to ensime (i.e. there is a sbt project for this scala buffer and ensime is connected). I don't know why that is…. I didn't investigate further, because I thought it would be better to always wrap the dirname in `file-name-as-directory` when setting it to `default-directory`? 
