### PR TITLE
M-. in indirect buffer kills Ensime (#542)

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -928,7 +928,7 @@ copies. All other objects are used unchanged. List must not contain cycles."
 
 (defun ensime-rpc-symbol-at-point ()
   (ensime-eval
-   `(swank:symbol-at-point ,buffer-file-name ,(ensime-computed-point))))
+   `(swank:symbol-at-point ,(buffer-file-name-with-indirect) ,(ensime-computed-point))))
 
 (defun ensime-rpc-remove-file (file-name)
   (ensime-eval `(swank:remove-file ,file-name)))
@@ -963,7 +963,7 @@ copies. All other objects are used unchanged. List must not contain cycles."
 (defun ensime-rpc-import-suggestions-at-point (names max-results)
   (ensime-eval
    `(swank:import-suggestions
-     ,buffer-file-name
+     ,(buffer-file-name-with-indirect)
      ,(ensime-computed-point)
      ,names
      ,max-results
@@ -988,7 +988,7 @@ copies. All other objects are used unchanged. List must not contain cycles."
 (defun ensime-rpc-uses-of-symbol-at-point ()
   (ensime-eval
    `(swank:uses-of-symbol-at-point
-     ,buffer-file-name
+     ,(buffer-file-name-with-indirect)
      ,(ensime-computed-point)
      )))
 
@@ -1008,11 +1008,11 @@ copies. All other objects are used unchanged. List must not contain cycles."
 (defun ensime-rpc-get-type-by-name-at-point (name)
   (ensime-eval
    `(swank:type-by-name-at-point
-     ,name ,buffer-file-name ,(ensime-computed-point))))
+     ,name ,(buffer-file-name-with-indirect) ,(ensime-computed-point))))
 
 (defun ensime-rpc-get-type-at-point ()
   (ensime-eval
-   `(swank:type-at-point ,buffer-file-name ,(ensime-computed-point))))
+   `(swank:type-at-point ,(buffer-file-name-with-indirect) ,(ensime-computed-point))))
 
 (defun ensime-rpc-inspect-type-at-point ()
   (ensime-eval
@@ -1020,7 +1020,7 @@ copies. All other objects are used unchanged. List must not contain cycles."
 
 (defun ensime-rpc-inspect-type-at-range (&optional range)
   (ensime-eval
-   `(swank:inspect-type-at-point ,buffer-file-name
+   `(swank:inspect-type-at-point ,(buffer-file-name-with-indirect)
                                  ,(or range (ensime-computed-range)))))
 
 (defun ensime-rpc-inspect-type-by-id (id)
@@ -1076,7 +1076,7 @@ copies. All other objects are used unchanged. List must not contain cycles."
 
 (defun ensime-rpc-implicit-info-in-range (start end)
   (ensime-eval `(swank:implicit-info
-                 ,(buffer-file-name)
+                 ,(buffer-file-name-with-indirect)
                  (,(ensime-externalize-offset start) ,(ensime-externalize-offset end)))))
 
 (defun ensime-rpc-get-call-completion (id)

--- a/ensime-company.el
+++ b/ensime-company.el
@@ -151,7 +151,7 @@ been inserted immediately prior to the point."
          (type-info (get-text-property 0 'type-info candidate))
          (is-callable (plist-get type-info :arrow-type))
          (name-start-point (- (point) (length name)))
-         (is-scala (ensime-scala-file-p buffer-file-name))
+         (is-scala (ensime-scala-file-p (buffer-file-name-with-indirect)))
 
          (param-sections
           ;; ignore implicit sections

--- a/ensime-config.el
+++ b/ensime-config.el
@@ -46,7 +46,7 @@
   ;; this is a good candidate for caching
   (let ((config (or config (ensime-config-for-buffer))))
    (let* ((case-insensitive-fs t) ;; https://github.com/ensime/ensime-emacs/issues/532
-          (canonical (convert-standard-filename buffer-file-name))
+          (canonical (convert-standard-filename (buffer-file-name-with-indirect)))
           (subprojects (plist-get config :subprojects))
           (matches-subproject-dir? (lambda (dir) (s-starts-with-p dir canonical case-insensitive-fs)))
           (find-subproject (lambda (sp)

--- a/ensime-doc.el
+++ b/ensime-doc.el
@@ -33,11 +33,10 @@
 (defun ensime-show-doc-for-symbol-at-point ()
   "Browse to documentation for the symbol at current point."
   (interactive)
-  (let* ((url (ensime-rpc-doc-uri-at-point buffer-file-name (point))))
+  (let* ((url (ensime-rpc-doc-uri-at-point (buffer-file-name-with-indirect) (point))))
     (if url (browse-url (ensime--normalise-url url))
       (message "No documentation found."))))
 
 (provide 'ensime-doc)
 ;; Local Variables:
 ;; End:
-

--- a/ensime-goto-testfile.el
+++ b/ensime-goto-testfile.el
@@ -14,7 +14,7 @@ filled with a stub test class.
 With an argument, open the test file in another window."
   (interactive "P")
   (block nil
-    (when (ensime-is-test-file buffer-file-name)
+    (when (ensime-is-test-file (buffer-file-name-with-indirect))
       (message "This isn't an implementation file")
       (return))
     (let* ((impl-class
@@ -36,7 +36,7 @@ With an argument, open the test file in another window."
 implementation class. With an argument, open the test file in another window."
   (interactive "P")
   (block nil
-    (unless (ensime-is-test-file buffer-file-name)
+    (unless (ensime-is-test-file (buffer-file-name-with-indirect))
       (message "This isn't a test file")
       (return))
     (let ((test-class (ensime-top-level-class-closest-to-point)))
@@ -180,8 +180,8 @@ the file with stub code. if the file already exists, simply visit it."
   "Return the name of the file that should contain the test class
 TEST-CLASS-NAME. The current buffer must be the file that contains the
 implementation class."
-  (let* ((impl-base-dir (ensime-source-base-dir-for-file buffer-file-name))
-         (impl-extension (file-name-extension buffer-file-name t))
+  (let* ((impl-base-dir (ensime-source-base-dir-for-file (buffer-file-name-with-indirect)))
+         (impl-extension (file-name-extension (buffer-file-name-with-indirect) t))
          (test-relative-path
           (concat
            (replace-regexp-in-string "\\." "/" test-class-name)

--- a/ensime-macros.el
+++ b/ensime-macros.el
@@ -209,7 +209,7 @@ corresponding values in the CDR of VALUE."
  file's state."
   `(let ((,file-sym (ensime-temp-file-name
 		     (concat ".tmp_" (file-name-nondirectory
-				      buffer-file-name)))))
+				      (buffer-file-name-with-indirect))))))
      (ensime-write-buffer ,file-sym)
      ,@body))
 

--- a/ensime-notes.el
+++ b/ensime-notes.el
@@ -225,7 +225,7 @@ any buffer visiting the given file."
         (max-external-offset (ensime-externalize-offset (point-max))))
     (dolist (note notes)
       (if (and (ensime-files-equal-p (ensime-note-file note)
-				     buffer-file-name)
+				     (buffer-file-name-with-indirect))
 	       (/= (ensime-note-beg note) external-offset))
 	  (let ((dist (cond
 		       (forward

--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -59,13 +59,13 @@
   "Save the current buffer and compile it using `sbt-ensime's `ensimeCompileOnly' Task."
   (interactive)
   (save-buffer)
-  (ensime-sbt-run-command-in-subproject "ensimeCompileOnly" buffer-file-name))
+  (ensime-sbt-run-command-in-subproject "ensimeCompileOnly" (buffer-file-name-with-indirect)))
 
 (defun ensime-sbt-do-scalariform-only ()
   "Format the current file using Scalariform."
   (interactive)
   (save-buffer)
-  (ensime-sbt-run-command-in-subproject "ensimeScalariformOnly" buffer-file-name))
+  (ensime-sbt-run-command-in-subproject "ensimeScalariformOnly" (buffer-file-name-with-indirect)))
 
 (defun ensime-sbt-run-command-in-subproject (command file-name)
   "Run a sbt COMMAND in the module containing FILE-NAME, if specified."
@@ -170,7 +170,7 @@ again."
     (concat module "/" source-set task)))
 
 (defun ensime-sbt-test-dwim (command)
-  (let* ((file-name (or buffer-file-name default-directory))
+  (let* ((file-name (or (buffer-file-name-with-indirect) default-directory))
          (source-set (cond
                       ((string-match-p "src/test" file-name) "")
                       ((string-match-p "/test" file-name) "") ;; for Play's default dir layout

--- a/ensime-search.el
+++ b/ensime-search.el
@@ -138,7 +138,7 @@
 
        (message "Already in ensime-search buffer")
 
-     (when buffer-file-name
+     (when (buffer-file-name-with-indirect)
        (setq ensime-search-originating-buffer (current-buffer)))
 
      (setq ensime-search-window-config (current-window-configuration))

--- a/ensime.el
+++ b/ensime.el
@@ -35,7 +35,7 @@
   "Read config file for settings then start an ensime-server and connect."
   (interactive)
   (ensime-startup-notifications)
-  (let ((orig-bfn buffer-file-name))
+  (let ((orig-bfn (buffer-file-name-with-indirect)))
     (condition-case ex
         (if ensime-auto-generate-config
             (ensime--maybe-refresh-config


### PR DESCRIPTION
It turns out that almost any operation in indirect buffers caused ensime to crash. This PR is fixing it, so now it is possible to do any operation in indirect buffer as if it was regular buffer.