### PR TITLE
Put .ensime_cache/dep-src/source-jars directory into cache even when

### DIFF
--- a/ensime-config.el
+++ b/ensime-config.el
@@ -102,8 +102,7 @@
 	 (puthash (file-name-as-directory (file-truename f)) t result)))
      (unless no-ref-sources
        (-when-let (f (ensime-source-jars-dir conf))
-	 (when (file-directory-p f)
-	   (puthash (file-name-as-directory (file-truename f)) t result))))
+         (puthash (file-name-as-directory (file-truename f)) t result)))
 
      (setq ensime--cache-source-root-set
 	   (cons (cons (list conf no-ref-sources) result)


### PR DESCRIPTION
it doesn't exists.

This is fix for the case when sources in
.ensime_cache/dep-src/source-jars weren't navigable due to cache
ensime--cache-source-root-set not including
.ensime_cache/dep-src/source-jars since it doesn't existed when the
project were created.