### PR TITLE
Fix test commands in SBT menu

### DIFF
--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -114,6 +114,7 @@
       (define-key prefix-map (kbd "C-b o") 'ensime-sbt-do-test-only-dwim)
       (define-key prefix-map (kbd "C-b p") 'ensime-sbt-do-package)
       (define-key prefix-map (kbd "C-b r") 'ensime-sbt-do-run)
+      (define-key prefix-map (kbd "C-b T") 'ensime-sbt-do-test)
       (define-key prefix-map (kbd "C-b t") 'ensime-sbt-do-test-dwim)
       (define-key prefix-map (kbd "C-b q") 'ensime-sbt-do-test-quick-dwim)
 
@@ -238,8 +239,9 @@
      ["Compile only" ensime-sbt-do-compile-only]
      ["Clean" ensime-sbt-do-clean]
      ["Test" ensime-sbt-do-test]
-     ["Test Quick" ensime-sbt-do-test-quick]
-     ["Test current class" ensime-sbt-do-test-only]
+     ["Test module/suite" ensime-sbt-do-test-dwim]
+     ["Test quick" ensime-sbt-do-test-quick-dwim]
+     ["Test current class" ensime-sbt-do-test-only-dwim]
      ["Format source" ensime-sbt-do-scalariform-only]
      ["Run" ensime-sbt-do-run]
      ["Package" ensime-sbt-do-package])

--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -193,6 +193,11 @@ again."
                (key-description
                 (where-is-internal this-command overriding-local-map t))))))
 
+(defun ensime-sbt-do-test ()
+  "Run all the tests."
+  (interactive)
+  (sbt-command "test"))
+
 (defun ensime-sbt-do-test-dwim ()
   "Execute the sbt `test' command for the project and suite that
 corresponds to the current source test file.


### PR DESCRIPTION
Broken when dwim was added in 6d83487

Add back `ensime-sbt-do-test` and bind to `C-c C-b T`.  This is
consistent with the documentation:

http://ensime.org/editors/emacs/cheat_sheet/

I'll update the cheat sheet to be consistent with the latest in ensime/ensime.github.io#227
