### PR TITLE
Propertize eldoc messages.

### DIFF
--- a/ensime-eldoc.el
+++ b/ensime-eldoc.el
@@ -17,9 +17,9 @@
   (when (ensime-connected-p)
     (let ((msg (pcase ensime-eldoc-hints
                  (`error
-                  (ensime-errors-at (point)))
+                  (mapconcat 'identity (ensime-errors-at (point)) "\n"))
                  (`implicit
-                  (ensime-implicit-notes-at (point)))
+                  (mapconcat 'identity (ensime-implicit-notes-at (point)) "\n"))
                  (`type
                   (ensime-eldoc-type-info))
                  (`all
@@ -28,8 +28,8 @@
                          (type (ensime-eldoc-type-info)))
                     (format "%s\n%s\n%s"
                             type
-                            (if implicit implicit "")
-                            (if error-msg error-msg "")))))))
+                            (mapconcat 'identity implicit "\n")
+                            (mapconcat 'identity error-msg "\n")))))))
       (eldoc-message (s-trim msg)))))
 
 (defun ensime-eldoc-type-info ()

--- a/ensime-eldoc.el
+++ b/ensime-eldoc.el
@@ -23,13 +23,10 @@
                  (`type
                   (or (ensime-eldoc-type-info) ""))
                  (`all
-                  (let* ((error-msg (ensime-errors-at (point)))
-                         (implicit (ensime-implicit-notes-at (point)))
-                         (type (ensime-eldoc-type-info)))
-                    (format "%s\n%s\n%s"
-                            (or type "")
-                            (mapconcat 'identity implicit "\n")
-                            (mapconcat 'identity error-msg "\n")))))))
+                  (format "%s\n%s\n%s"
+                          (or (ensime-eldoc-type-info) "")
+                          (mapconcat 'identity (ensime-implicit-notes-at (point)) "\n")
+                          (mapconcat 'identity (ensime-errors-at (point)) "\n"))))))
       (eldoc-message (s-trim msg)))))
 
 (defun ensime-eldoc-type-info ()

--- a/ensime-eldoc.el
+++ b/ensime-eldoc.el
@@ -21,13 +21,13 @@
                  (`implicit
                   (mapconcat 'identity (ensime-implicit-notes-at (point)) "\n"))
                  (`type
-                  (ensime-eldoc-type-info))
+                  (or (ensime-eldoc-type-info) ""))
                  (`all
                   (let* ((error-msg (ensime-errors-at (point)))
                          (implicit (ensime-implicit-notes-at (point)))
                          (type (ensime-eldoc-type-info)))
                     (format "%s\n%s\n%s"
-                            type
+                            (or type "")
                             (mapconcat 'identity implicit "\n")
                             (mapconcat 'identity error-msg "\n")))))))
       (eldoc-message (s-trim msg)))))
@@ -39,8 +39,10 @@
            (type (ensime-rpc-get-type-at-point))
            (name (plist-get symbol :local-name))
            (type-name (ensime-type-name-with-args type)))
-      (when (and type (not (string= type-name "<none>")))
-        (format "%s: %s" name type-name)))))
+      (when (and name type (not (string= type-name "<none>")))
+        (format "%s: %s"
+                (propertize name 'face 'font-lock-variable-name-face)
+                (propertize type-name 'face 'font-lock-type-face))))))
 
 (provide 'ensime-eldoc)
 


### PR DESCRIPTION
### Propertizing implicit information

`ensime-implicit-notes-at` returns propertized messages (in a list) but the properties were dropped because we were passing the list to `"%s"` of `format`.  `mapconcat`ing the list will preserve the properties.  We should do the same for `ensime-errors-at`, which also returns messages in a list.

### Propertizing type information

I think it is also nice to have it propertized.  Note that the local name of a symbol may be missing, which results in printing `nil: SomeType` in the original code.  We simply ignore symbols without a local name in this PR.