### PR TITLE
fix for outdated build tool startup notification error 

### DIFF
--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -139,7 +139,7 @@ that you have read this message.")
          (server-flags (or (plist-get config :java-flags) ensime-default-java-flags)))
     (make-directory cache-dir 't)
 
-    (unless (or ensime-server-jars
+    (unless (and ensime-server-jars
                 ensime-server-version)
       (error (concat
               "\n\n"


### PR DESCRIPTION
it fix bug added by #615
```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  string-match("-M" nil nil)
  s-contains\?("-M" nil)
  (lambda (s) (s-contains\? s version))("-M")
  mapcar((lambda (s) (s-contains\? s version)) ("-M" "-RC" "SNAPSHOT"))
  -map((lambda (s) (s-contains\? s version)) ("-M" "-RC" "SNAPSHOT"))
  (-contains\? (-map (function (lambda (s) (s-contains\? s version))) (quote ("-M" "-RC" "SNAPSHOT"))) t)
  ensime-dev-version-p(nil)
  (if (ensime-dev-version-p ensime-server-version) nil (error (concat "\n\n" "Your build tool has downloaded the stable version of ENSIME " "but you are using the Developer Emacs install.\n\n" "Check that you followed all the steps at http://ensime.org/editors/emacs/install " "including additional steps that are required by your build tool.\n\n" "For SBT, add the following to your ~/.sbt/0.13/global.sbt\n\n" "	 import org.ensime.EnsimeCoursierKeys._\n" "	 ensimeServerVersion in ThisBuild := \"2.0.0-M1\"\n\n" "Currently other build tools do not support 2.0 file format.\n\n")))
  (let* ((config (ensime-config-load config-file)) (root-dir (ensime--get-root-dir config)) (cache-dir (file-name-as-directory (ensime--get-cache-dir config))) (name (ensime--get-name config)) (ensime-server-jars (plist-get config :ensime-server-jars)) (ensime-server-version (plist-get config :ensime-server-version)) (scala-compiler-jars (plist-get config :scala-compiler-jars)) (server-env (or (plist-get config :server-env) ensime-default-server-env)) (buffer (or (plist-get config :buffer) (concat ensime-default-buffer-prefix name))) (server-java (file-name-as-directory (ensime--get-java-home config))) (server-flags (or (plist-get config :java-flags) ensime-default-java-flags))) (make-directory cache-dir (quote t)) (if (or ensime-server-jars ensime-server-version) nil (error (concat "\n\n" "You are using a .ensime file format that is no longer supported.\n" "You must upgrade your build tool or downgrade to ensime stable.\n" "See http://ensime.org/editors/emacs/install\n\n"))) (if (ensime-dev-version-p ensime-server-version) nil (error (concat "\n\n" "Your build tool has downloaded the stable version of ENSIME " "but you are using the Developer Emacs install.\n\n" "Check that you followed all the steps at http://ensime.org/editors/emacs/install " "including additional steps that are required by your build tool.\n\n" "For SBT, add the following to your ~/.sbt/0.13/global.sbt\n\n" "	 import org.ensime.EnsimeCoursierKeys._\n" "	 ensimeServerVersion in ThisBuild := \"2.0.0-M1\"\n\n" "Currently other build tools do not support 2.0 file format.\n\n"))) (let* ((server-proc (ensime--maybe-start-server (generate-new-buffer-name (concat "*" buffer "*")) server-java (append ensime-server-jars scala-compiler-jars) server-flags (cons (concat "JAVA_HOME=" server-java) server-env) config-file cache-dir)) (host "127.0.0.1") (port-fn (function (lambda nil (ensime--read-portfile (concat cache-dir "/port")))))) (process-put server-proc :ensime-config config) (setq ensime-server-processes (cons server-proc ensime-server-processes)) (ensime--retry-connect server-proc host port-fn config cache-dir)))
  (progn (if (and (ensime-source-file-p) (not ensime-mode)) (progn (ensime-mode 1))) (let* ((config (ensime-config-load config-file)) (root-dir (ensime--get-root-dir config)) (cache-dir (file-name-as-directory (ensime--get-cache-dir config))) (name (ensime--get-name config)) (ensime-server-jars (plist-get config :ensime-server-jars)) (ensime-server-version (plist-get config :ensime-server-version)) (scala-compiler-jars (plist-get config :scala-compiler-jars)) (server-env (or (plist-get config :server-env) ensime-default-server-env)) (buffer (or (plist-get config :buffer) (concat ensime-default-buffer-prefix name))) (server-java (file-name-as-directory (ensime--get-java-home config))) (server-flags (or (plist-get config :java-flags) ensime-default-java-flags))) (make-directory cache-dir (quote t)) (if (or ensime-server-jars ensime-server-version) nil (error (concat "\n\n" "You are using a .ensime file format that is no longer supported.\n" "You must upgrade your build tool or downgrade to ensime stable.\n" "See http://ensime.org/editors/emacs/install\n\n"))) (if (ensime-dev-version-p ensime-server-version) nil (error (concat "\n\n" "Your build tool has downloaded the stable version of ENSIME " "but you are using the Developer Emacs install.\n\n" "Check that you followed all the steps at http://ensime.org/editors/emacs/install " "including additional steps that are required by your build tool.\n\n" "For SBT, add the following to your ~/.sbt/0.13/global.sbt\n\n" "	 import org.ensime.EnsimeCoursierKeys._\n" "	 ensimeServerVersion in ThisBuild := \"2.0.0-M1\"\n\n" "Currently other build tools do not support 2.0 file format.\n\n"))) (let* ((server-proc (ensime--maybe-start-server (generate-new-buffer-name (concat "*" buffer "*")) server-java (append ensime-server-jars scala-compiler-jars) server-flags (cons (concat "JAVA_HOME=" server-java) server-env) config-file cache-dir)) (host "127.0.0.1") (port-fn (function (lambda nil (ensime--read-portfile ...))))) (process-put server-proc :ensime-config config) (setq ensime-server-processes (cons server-proc ensime-server-processes)) (ensime--retry-connect server-proc host port-fn config cache-dir))))
  ensime--1("/Users/aaronhawley/git/scala-xml/.ensime")
  (if (and host port) (let ((cache-dir (file-name-as-directory (ensime--get-cache-dir config)))) (ensime--retry-connect nil host (function (lambda nil port)) config cache-dir)) (ensime--1 config-file))
  (let* ((config-file (ensime-config-find orig-buffer-file-name)) (config (ensime-config-load config-file))) (if (and host port) (let ((cache-dir (file-name-as-directory (ensime--get-cache-dir config)))) (ensime--retry-connect nil host (function (lambda nil port)) config cache-dir)) (ensime--1 config-file)))
  ensime--maybe-update-and-start(nil)
  ensime()
  funcall-interactively(ensime)
```