### PR TITLE
Delete duplicate import lines, when organize java imports.

### DIFF
--- a/ensime-refactor.el
+++ b/ensime-refactor.el
@@ -44,18 +44,19 @@
   "Key bindings for the refactor confirmation popup.")
 
 (defun ensime-refactor-organize-java-imports ()
-  "Sort all import statements lexicographically."
+  "Sort all import statements lexicographically and delete the duplicate imports."
   (save-excursion
     (goto-char (point-min))
     (search-forward-regexp "^\\s-*package\\s-" nil t)
     (goto-char (point-at-eol))
-    (let ((p (point)))
-
+    (let ((beg (point)) end)
       ;; Advance past all imports
       (while (looking-at "[\n\t ]*import\\s-\\(.+\\)\n")
-	(search-forward-regexp "import" nil t)
-	(goto-char (point-at-eol)))
-      (sort-lines nil p (point)))))
+        (search-forward-regexp "import" nil t)
+        (goto-char (point-at-eol)))
+      (setq end (point))
+      (sort-lines nil beg end)
+      (delete-duplicate-lines beg end nil t))))
 
 (defun ensime-refactor-diff-rename (&optional new-name)
   "Rename a symbol, project-wide."

--- a/ensime-startup.el
+++ b/ensime-startup.el
@@ -205,7 +205,7 @@ that you have read this message.")
 Analyzer will be restarted."
   (interactive)
   (ensime-shutdown)
-  (ensime))
+  (call-interactively 'ensime))
 
 (defun ensime--maybe-start-server (buffer java-home classpath flags env config-file cache-dir)
   "Return a new or existing server process."


### PR DESCRIPTION
Delete the import duplicate lines.
