### PR TITLE
fix ensime-show-uses-of-symbol-at-point (#638)

### DIFF
--- a/ensime-popup.el
+++ b/ensime-popup.el
@@ -66,6 +66,11 @@ The buffer also uses the minor-mode `ensime-popup-buffer-mode'."
   (multiple-value-setq (ensime-buffer-connection)
     buffer-vars))
 
+(defun ensime-popup-buffer-p (buffer)
+  "Is this an ensime popup buffer?"
+  (with-current-buffer buffer
+    ensime-is-popup-buffer))
+
 (defun ensime-display-popup-buffer (select)
   "Display the current buffer.
    Save the selected-window in a buffer-local variable, so that we


### PR DESCRIPTION
this is fixing #638 

this was the only usage of `ensime-popup-buffer-p` and as it is directly related about popup I've just copied function from deleted file.