### PR TITLE
Fixed minor copy/paste bug in error message.

### DIFF
--- a/ensime-search.el
+++ b/ensime-search.el
@@ -138,7 +138,7 @@
     (`ivy
      (if (featurep 'ivy)
          (ensime-search-ivy)
-       (message "Please ensure helm is installed and loaded.")))))
+       (message "Please ensure ivy is installed and loaded.")))))
 
 (defun ensime-search-classic ()
   "The classic entrypoint for ensime-search-mode.


### PR DESCRIPTION
Just a tiny correction of an error message when ivy is not installed but used as search interface.