### PR TITLE
classic show uses and type hierarchy

### DIFF
--- a/ensime-client.el
+++ b/ensime-client.el
@@ -989,6 +989,13 @@ copies. All other objects are used unchanged. List must not contain cycles."
      ,(ensime-computed-point)
      )))
 
+(defun ensime-rpc-hierarchy-of-type-at-point ()
+  (ensime-eval
+   `(swank:hierarchy-of-type-at-point
+     ,(ensime-src-info-with-contents-in-temp)
+     ,(ensime-computed-point)
+     )))
+
 (defun ensime-rpc-package-member-completions (path &optional prefix)
   (ensime-eval
    `(swank:package-member-completion ,path ,(or prefix ""))))

--- a/ensime-helm.el
+++ b/ensime-helm.el
@@ -11,18 +11,11 @@
 
 (defun ensime-helm-select-source-position (positions name)
   "Select one source position element using helm"
-  (let ((name-alist (mapcar (lambda (elem) (cons (ensime-helm-format-source-position-element elem) elem)) positions)))
+  (let ((name-alist (mapcar (lambda (elem) (cons (ensime-format-source-position elem) elem)) positions)))
   (helm :sources (helm-build-sync-source name
                    :candidates name-alist
                    :fuzzy-match t))))
 
-(defun ensime-helm-format-source-position-element (element)
-  "Format source position element"
-    (let* ((file-name (ensime-pos-file element))
-           (maybe-line (ensime-pos-line element)))
-      (let ((line (if maybe-line (number-to-string maybe-line) "?")))
-       (concat file-name
-       (propertize (concat ":" line) 'face 'font-lock-comment-face)))))
 
 (defun ensime-helm-select-entry (entries name)
   "Select one entry using helm"

--- a/ensime-model.el
+++ b/ensime-model.el
@@ -171,6 +171,15 @@
 (defun ensime-note-message (note)
   (plist-get note :msg))
 
+(defun ensime-type-ancestors (type)
+  (plist-get type :ancestors))
+
+(defun ensime-type-inheritors (type)
+  (plist-get type :inheritors))
+
+(defun ensime-type-fqn (type)
+  (plist-get type :fqn))
+
 (provide 'ensime-model)
 
 ;; Local Variables:


### PR DESCRIPTION
Not particularly pretty but it works.


I tried to write a feature file for the formatter but ecukes complains about a missing method.
`Symbol’s value as variable is void: imenu-auto-rescan`