### PR TITLE
[feat] add ensime static search

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -897,15 +897,17 @@ falls back to the classic version."
 
 (defun ensime-format-source-position (source-position)
   "Format source position SOURCE-POSITION."
-  (let* ((file-name (ensime-pos-file source-position))
-         (maybe-line (ensime-pos-line source-position))
-         (root-dir (ensime-configured-project-root))
-         (shortened-file-name (if root-dir
-                                  (replace-regexp-in-string (concat "^" (regexp-quote (expand-file-name root-dir)) "[/]?") "" file-name)
-                                file-name)))
-    (let ((line (if maybe-line (number-to-string (if (= 0 maybe-line) 1 maybe-line)) "?")))
-      (concat shortened-file-name
-              (propertize (concat ":" line) 'face 'font-lock-comment-face)))))
+  (if source-position
+      (let* ((file-name (ensime-pos-file source-position))
+             (maybe-line (ensime-pos-line source-position))
+             (root-dir (ensime-configured-project-root))
+             (shortened-file-name (if root-dir
+                                      (replace-regexp-in-string (concat "^" (regexp-quote (expand-file-name root-dir)) "[/]?") "" file-name)
+                                    file-name)))
+        (let ((line (if maybe-line (number-to-string (if (= 0 maybe-line) 1 maybe-line)) "?")))
+          (concat shortened-file-name
+                  (propertize (concat ":" line) 'face 'font-lock-comment-face))))
+    "???:?"))
 
 
 

--- a/ensime-search.el
+++ b/ensime-search.el
@@ -126,21 +126,25 @@
   (summary-start 0)
   (data nil))
 
-(defun ensime-search ()
+(defun ensime-search (&optional arg)
   "The main entrypoint for ensime-search-mode.
-   Initiate an incremental search of all live buffers."
-  (interactive)
-  (pcase ensime-search-interface
-    (`classic
-     (ensime-search-classic))
-    (`helm
-     (if (featurep 'helm)
-         (ensime-helm-search)
-       (message "Please ensure helm is installed and loaded.")))
-    (`ivy
-     (if (featurep 'ivy)
-         (ensime-search-ivy)
-       (message "Please ensure ivy is installed and loaded.")))))
+   Initiate an incremental search of all live buffers. If
+   provided with the universal argument uses
+   ensime-static-search"
+  (interactive "P")
+  (if (equal arg '(4))
+      (ensime-static-search)
+    (pcase ensime-search-interface
+      (`classic
+       (ensime-search-classic))
+      (`helm
+       (if (featurep 'helm)
+           (ensime-helm-search)
+         (message "Please ensure helm is installed and loaded.")))
+      (`ivy
+       (if (featurep 'ivy)
+           (ensime-search-ivy)
+         (message "Please ensure ivy is installed and loaded."))))))
 
 (defun ensime-static-search ()
   "Does a search an displays the result in a grep buffer."

--- a/ensime-search.el
+++ b/ensime-search.el
@@ -44,6 +44,8 @@
 (defvar ensime-search-target-buffer-name "*ensime-search-results*"
   "Buffer name for target-buffer.")
 
+(defvar ensime-static-search-buffer-name "*Ensime Static Search*")
+
 (defvar ensime-search-target-buffer nil
   "Buffer to which the ensime-search is applied to.")
 
@@ -139,6 +141,27 @@
      (if (featurep 'ivy)
          (ensime-search-ivy)
        (message "Please ensure ivy is installed and loaded.")))))
+
+(defun ensime-static-search ()
+  "Does a search an displays the result in a grep buffer."
+  (interactive)
+  (let* ((search-string (read-string "Search: "))
+         (search-results (ensime-rpc-public-symbol-search
+                          (split-string search-string " ") ensime-search-max-results)))
+    (switch-to-buffer (get-buffer-create ensime-static-search-buffer-name))
+    (setq buffer-read-only nil)
+    (erase-buffer)
+    (insert (concat "Ensime search results for " search-string ":"  "\n\n"))
+    (dolist (search-result search-results)
+      (let* ((pos (ensime-search-sym-pos search-result))
+             (formatted-pos (ensime-format-source-position pos))
+             (name (ensime-search-sym-name search-result)))
+        (insert formatted-pos)
+        (insert ": ")
+        (insert name)
+        (insert "\n")))
+    (goto-char 0)
+    (grep-mode)))
 
 (defun ensime-search-classic ()
   "The classic entrypoint for ensime-search-mode.


### PR DESCRIPTION
Shows ensime search results in a grep buffer.

If this works good I would use the universal argument for ensime-search to trigger this.

Alternatively we could replace the classic-search with this. Users would lose interactive search though.