### PR TITLE
Fixing ensime-helm-select-source-position to display previews

### DIFF
--- a/ensime-helm.el
+++ b/ensime-helm.el
@@ -9,9 +9,19 @@
 
 (require 'helm "helm.el" t)
 
+(defun string-or-empty (str)
+  "Returns the string or empty string if nil"
+  (if str str ""))
+
 (defun ensime-helm-select-source-position (positions name)
   "Select one source position element using helm"
-  (let ((name-alist (mapcar (lambda (elem) (cons (ensime-format-source-position (ensime-source-hint-position elem)) elem)) positions)))
+  (let ((name-alist (mapcar
+                     (lambda (elem) (cons
+                                     (concat
+                                      (ensime-format-source-position (ensime-source-hint-position elem))
+                                      " "
+                                      (propertize (string-or-empty (ensime-preview elem)) 'face 'font-lock-doc-face))
+                                     elem)) positions)))
   (helm :sources (helm-build-sync-source name
                    :candidates name-alist
                    :fuzzy-match t))))

--- a/ensime-helm.el
+++ b/ensime-helm.el
@@ -9,10 +9,6 @@
 
 (require 'helm "helm.el" t)
 
-(defun string-or-empty (str)
-  "Returns the string or empty string if nil"
-  (if str str ""))
-
 (defun ensime-helm-select-source-position (positions name)
   "Select one source position element using helm"
   (let ((name-alist (mapcar
@@ -20,7 +16,7 @@
                                      (concat
                                       (ensime-format-source-position (ensime-source-hint-position elem))
                                       " "
-                                      (propertize (string-or-empty (ensime-preview elem)) 'face 'font-lock-doc-face))
+                                      (propertize (or (ensime-preview elem) "" ) 'face 'font-lock-doc-face))
                                      elem)) positions)))
   (helm :sources (helm-build-sync-source name
                    :candidates name-alist

--- a/ensime-model.el
+++ b/ensime-model.el
@@ -186,6 +186,9 @@
 (defun ensime-source-hint-position (hint)
   (plist-get hint :position))
 
+(defun ensime-preview (hint)
+  (plist-get hint :preview))
+
 
 
 (provide 'ensime-model)


### PR DESCRIPTION
Fixing `ensime-helm-select-source-position` - (`C-c C-v r` with `ensime-search-interface` = `'helm` so that previews are displayed.

![helm-with](https://user-images.githubusercontent.com/91761/31169892-77fcc5a2-a8fa-11e7-93e0-adff98d31bc7.png)

instead of 

![helm-without](https://user-images.githubusercontent.com/91761/31169975-b9e124d6-a8fa-11e7-8341-1aef9af4b9e4.png)

