### PR TITLE
Fix #682 by making ensime-edit-definition function first argument optional

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -274,7 +274,7 @@
   (interactive "P")
   (ensime-edit-definition arg 'frame))
 
-(defun ensime-edit-definition (arg &optional where)
+(defun ensime-edit-definition (&optional arg where)
   "Lookup the definition of the name at point.
 
 If provided with the universal arguments looks up the definition


### PR DESCRIPTION
The function ensime-edit-definition is used non interactively by ensime-control-mouse-1-single-click which then fails as it calls the function without argument. As this argument is not required to perform the action, marking it as optional.