### PR TITLE
Fix ensime-sbt-do-test-only-dwim on sbt 1.x

### DIFF
--- a/ensime-sbt.el
+++ b/ensime-sbt.el
@@ -265,7 +265,7 @@ module, test suite and test command."
           (or (ensime-top-level-class-closest-to-point)
               (return (message "Could not find top-level class"))))
          (cleaned-class (replace-regexp-in-string "<empty>\\." "" impl-class))
-         (command (concat "test-only" " " cleaned-class)))
+         (command (concat "testOnly" " " cleaned-class)))
     (ensime-sbt-test-dwim command)))
 
 


### PR DESCRIPTION
Currently, running `C-c C-b o` in a test file on an sbt 1.x project gives this error:

    sbt:root> foo/test-only com.my.Test
    [error] Expected configuration
    [error] Expected ':'
    [error] Expected key
    [error] Not a valid key: test-only (similar: testOnly, test, testOptions)
    [error] foo/test-only com.my.Test
    [error]              ^

This is because we're trying to run `test-only`, which has been renamed to `testOnly`.  This commit fixes the issue.  I think it shouldn't cause problems for sbt 0.13.x users, since that version also supported `testOnly`.