### PR TITLE
Remove call to non-existent 'ensime-sbt-do-scalariform-only'

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -700,15 +700,6 @@ If user selects an import, add it to the import list."
               (ensime-typecheck-current-buffer)))))
       (message "No import suggestions were returned for %S" name))))
 
-;; Source Formatting - transition cue to sbt task
-(defun ensime-format-source ()
-  "DEPRECATED - use ensime-sbt-do-scalariform-only directly.
-Functionality was moved from ensime-server to the build tool plugins.
-Use build tools tasks appropriately"
-  (interactive)
-  (message "Function use is deprecated, please transition to ensime-sbt-do-scalariform-only.")
-  (ensime-sbt-do-scalariform-only))
-
 (defun ensime-revert-visited-files (files &optional typecheck)
   "files is a list of buffer-file-names to revert or lists of the form
  (visited-file-name disk-file-name) where buffer visiting visited-file-name

--- a/ensime-mode.el
+++ b/ensime-mode.el
@@ -98,7 +98,6 @@
       (define-key prefix-map (kbd "C-b S") 'ensime-stacktrace-switch)
       (define-key prefix-map (kbd "C-b c") 'ensime-sbt-do-compile)
       (define-key prefix-map (kbd "C-b C") 'ensime-sbt-do-compile-only)
-      (define-key prefix-map (kbd "C-b f") 'ensime-sbt-do-scalariform-only)
       (define-key prefix-map (kbd "C-b n") 'ensime-sbt-do-clean)
       (define-key prefix-map (kbd "C-b E") 'ensime-sbt-do-ensime-config)
       (define-key prefix-map (kbd "C-b o") 'ensime-sbt-do-test-only-dwim)
@@ -220,7 +219,6 @@
      ["Test module/suite" ensime-sbt-do-test-dwim]
      ["Test quick" ensime-sbt-do-test-quick-dwim]
      ["Test current class" ensime-sbt-do-test-only-dwim]
-     ["Format source" ensime-sbt-do-scalariform-only]
      ["Run" ensime-sbt-do-run]
      ["Package" ensime-sbt-do-package])
 


### PR DESCRIPTION
'ensime-sbt-do-scalariform-only' has been removed by:
3d3ab18436ad6089496b3bce1d49c64a86965431
