### PR TITLE
Remove a sleep that hinders M-x ensime-sbt

### DIFF
--- a/ensime-inf.el
+++ b/ensime-inf.el
@@ -335,7 +335,11 @@ Used for determining the default in the next one.")
 (defun ensime-inf-postoutput-filter (str)
   ;; Ideally we'd base this on comint's decision on whether it's seen
   ;; a prompt, but that decision hasn't been made by this stage
-  (sleep-for 0.1)
+
+  ; the sleep fights with sbt-comint... ensime-inf-overlay-marker is nil 
+  ; by default and so this filter is a noop by default
+  ; (sleep-for 0.1)
+
   (unless (or (string-equal str "") (string-equal "\n" (substring str -1)))
     (ensime-event-sig :inf-repl-ready)
     (when (markerp  ensime-inf-overlay-marker)


### PR DESCRIPTION
Instead of `M-x sbt-start`, I use `C-c C-b s` from my ensime buffer to start an sbt session.

This adds an additional `ensime-inf-postoutput-filter` to `comint-output-filter-functions`.  The adding of this filter seems largely historical as it is currently a no-op modulo a 100ms sleep.

This sleep however somehow manages to cause sbt-mode to improperly filter ansi colors for later versions of sbt (e.g., 1.1.5).

