### PR TITLE
Fixes infinite loop in refactoring

### DIFF
--- a/ensime-refactor.el
+++ b/ensime-refactor.el
@@ -229,10 +229,9 @@
   "Apply or undo all hunks in the diff contents of the current buffer."
   (interactive)
   (make-local-variable 'diff-advance-after-apply-hunk)
-  (setq diff-advance-after-apply-hunk nil)
+  (setq diff-advance-after-apply-hunk t)
   (goto-char (point-min))
-  (while (re-search-forward diff-hunk-header-re nil t)
-    (diff-apply-hunk)))
+  (diff-apply-hunk))
 
 (defun ensime-refactor-diff-save-source-files ()
   "Save all source files from the diff contents of the current buffer.


### PR DESCRIPTION
Fixes bug that the refactoring functions prompt endlessly:
> Hunk has already been applied; Undo it? (y or n)

Removes iteration of diff-header search results, in favour of functionality of `diff-apply-hunk`; to apply each hunk in sequence.

Tested in Emacs 26.1