### PR TITLE
ensime-local-sym-at-point fails when symbol is at end-of-line

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -431,8 +431,9 @@ the Scala files that are currently open in emacs."
           (search-backward-regexp "\\W" nil t)
           (setq start (+ (point) 1)))
         (save-excursion
-          (search-forward-regexp "\\W" nil t)
-          (setq end (- (point) 1)))
+          (if (search-forward-regexp "\\W" nil t)
+              (setq end (- (point) 1))
+            (setq end (point))))
         (list :start start
               :end end
               :name (buffer-substring-no-properties start end))))))


### PR DESCRIPTION
When a symbol is at the end of the line like:

    object Foo extends LazyLogging!

(Indicating `point` with `!`.)
Then, the value returned by `ensime-local-sym-at-point` is truncated to `LazyLoggin` (without the final `g`).

[Apologies if I have failed to obey the etiquette or norms of contributing to this project. It is not intentional. I will attempt to accept criticism with good grace.]