### PR TITLE
Fix inserting to multiline import groups

### DIFF
--- a/ensime-editor.el
+++ b/ensime-editor.el
@@ -526,7 +526,9 @@ Returns a function/closure to invoke the necessary buffer operations to perform 
         ((equal (point) (point-max)) (newline))
         ; if the import statement is at point-min we can't be above it and are actually at point-at-bol
         ((equal (point) (point-at-eol)) (forward-char 1)))
-      (kill-line)
+      (kill-line (length (s-lines current-import)))
+      (newline)
+      (forward-line -1)
       (->> (ensime-scala-new-import-grouped-package base-package new-imports)
            insert save-excursion)
       (ensime-indent-line))))
@@ -564,7 +566,7 @@ Decide what line to insert QUALIFIED-NAME."
 (defun ensime-scala-new-import-insertion-decisioning-in-import-block (insertion-range starting-point qualified-name)
   "Search through import statements in buffer above INSERTION-RANGE and STARTING-POINT.
 Decide what line to insert QUALIFIED-NAME."
-  (let ((looking-at-import? (looking-at "[\n\t ]*import\\s-\\(.+\\)\n"))
+  (let ((looking-at-import? (looking-at "[\n\t ]*import\\s-\\([^{\n]+\\({[^{}]*}\\)?\\)\n"))
         (matching-import (match-string 1)))
     (cond
      ;; insert at the end of the import block

--- a/features/scala-insert-import.feature
+++ b/features/scala-insert-import.feature
@@ -221,6 +221,38 @@ Feature: Insert Scala Import
     }
     """
 
+  Scenario: Insert Import Groups Import Under The Same Package Into Existing Multiline-Group
+    When I open temp scala file "test"
+    And I insert:
+    """
+    package com.example
+
+    import org.example.{
+      ClassA => AsB,
+      Example1,
+      Example3
+    }
+
+    class C {
+      def f = 1
+    }
+    """
+
+    And I go to line "10"
+    And I go to end of line
+    And I insert import "org.example.Example2"
+
+    Then I should see:
+    """
+    package com.example
+
+    import org.example.{ ClassA => AsB, Example1, Example2, Example3 }
+
+    class C {
+      def f = 1
+    }
+    """
+
   Scenario: Add Class to first import block in file
     When I open temp scala file "test"
     And I insert:


### PR DESCRIPTION
Currently, given the following block of code:

```scala
package com.example

import org.example.{
  ClassA => AsB,
  Example1,
  Example3
}

class C {
  def f = 1
}
```

Inserting a new import (by running `(progn (goto-char (point-max)) (ensime-insert-import "org.example.Example2"))`) generates the following invalid block of code:


```scala
package com.example

import org.example.{ , Example2 }
  ClassA => AsB,
  Example1,
  Example3
}

class C {
  def f = 1
}
```

This is because only the first line is considered part of the import. This change changes the Regex so that newlines are allowed in imports, but only within import groups (curly braces). 

# Caveats

The emitted import group will be merged into a single line:

```scala
package com.example

import org.example.{ ClassA => AsB, Example1, Example2, Example3 }

class C {
  def f = 1
}
```

My main priority was to not damage the AST, leaving the pretty-printing to Scalafmt.